### PR TITLE
ceph.spec.in: package the rbd udev rule on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -570,6 +570,7 @@ install -m 0644 -D udev/95-ceph-osd-alt.rules $RPM_BUILD_ROOT/lib/udev/rules.d/9
 %endif
 
 %if 0%{?suse_version}
+install -m 0644 -D udev/50-rbd.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/50-rbd.rules
 install -m 0644 -D systemd/udev-rules.d-95-ceph-osd.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/95-ceph-osd.rules
 %endif
 
@@ -727,7 +728,7 @@ mkdir -p %{_localstatedir}/run/ceph/
 %if 0%{?debian}
 /lib/udev/rules.d/50-rbd.rules
 %endif
-%if 0%{?rhel} >= 7 || 0%{?fedora}
+%if 0%{?rhel} >= 7 || 0%{?fedora} || 0%{?suse_version}
 /usr/lib/udev/rules.d/50-rbd.rules
 %endif
 %if 0%{?rhel} >= 7 || 0%{?fedora}


### PR DESCRIPTION
The 50-rbd.rules udev rule is required for the creation of
/dev/rbd/<pool>/<image> symlinks. This change ensures that it is
packaged on openSUSE and SLES platforms.

Signed-off-by: David Disseldorp <ddiss@suse.de>