### PR TITLE
src/ceph-disk: finish reverting 28fb607

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -1872,9 +1872,6 @@ def start_daemon(
                     ],
                 )
         elif os.path.exists(os.path.join(path, 'systemd')):
-            cname = ""
-            if cluster != "ceph":
-                cname = "%s-" % (cluster)
             command_check_call(
                 [
                     'systemctl',


### PR DESCRIPTION
28fb607 was reverted by b6eaf97 but not completely - this vestige was left behind.

Signed-off-by: Nathan Cutler <ncutler@suse.com>