### PR TITLE
ceph.spec.in: fix python-flask dependency for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -42,7 +42,6 @@ Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python
 Requires:	python-argparse
 Requires:	python-requests
-Requires:	python-flask
 Requires:	xfsprogs
 Requires:	parted
 Requires:	util-linux
@@ -111,6 +110,7 @@ BuildRequires:	nss-devel
 BuildRequires:	keyutils-libs-devel
 BuildRequires:	libatomic_ops-devel
 Requires:	gdisk
+Requires:	python-flask
 Requires(post):	chkconfig
 Requires(preun):chkconfig
 Requires(preun):initscripts
@@ -127,6 +127,7 @@ Requires:	scsirastools
 BuildRequires:	google-perftools-devel
 %endif
 Recommends:	logrotate
+Requires:	python-Flask
 BuildRequires:	%insserv_prereq
 BuildRequires:	mozilla-nss-devel
 BuildRequires:	keyutils-devel


### PR DESCRIPTION
In SLE and openSUSE, the package is called python-Flask with an upper-case F.

Signed-off-by: Nathan Cutler <ncutler@suse.com>