### PR TITLE
ceph.spec.in: restore 50-rbd.rules file in ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -825,6 +825,18 @@ mkdir -p %{_localstatedir}/run/ceph/
 %else
 /lib/udev/rules.d/50-rbd.rules
 %endif
+%if 0%{?suse_version}
+%if %suse_version >= 1310
+%dir /usr/lib/udev
+%dir /usr/lib/udev/rules.d
+/usr/lib/udev/rules.d/50-rbd.rules
+%endif
+%if %suse_version < 1310
+%dir /lib/udev
+%dir /lib/udev/rules.d
+/lib/udev/rules.d/50-rbd.rules
+%endif
+%endif
 
 %postun -n ceph-common
 # Package removal cleanup

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -820,6 +820,11 @@ mkdir -p %{_localstatedir}/run/ceph/
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{python_sitelib}/ceph_argparse.py*
+%if 0%{?rhel} >= 7 || 0%{?fedora}
+/usr/lib/udev/rules.d/50-rbd.rules
+%else
+/lib/udev/rules.d/50-rbd.rules
+%endif
 
 %postun -n ceph-common
 # Package removal cleanup


### PR DESCRIPTION
Commit f3ad61a6741e20f4b3bb8eac909f7ef384b18a88 was cherry-picked
properly but then commit b136bf5c297bdb47533b3251ac86354375d9f60a removed
part of it. The first commit in this PR restores that part. The second adds an analogous bit for SLE/openSUSE.