### PR TITLE
ceph.spec.in: install 50-rbd.rules in the right place

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -11,6 +11,10 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
 
+%if (0%{?rhel} && 0%{?rhel} < 7) || (0%{?suse_version} && 0%{?suse_version} < 1310)
+%global _udevrulesdir /lib/udev/rules.d
+%endif
+
 # Use systemd files on RHEL 7 and above and in SUSE/openSUSE.
 # Note: We don't install unit files for the services yet. For now,
 # the _with_systemd variable only implies that we'll install
@@ -566,16 +570,22 @@ install -m 0644 -D etc/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds %{buildro
 %endif
 
 # udev rules
-%if (0%{?rhel} >= 7 || 0%{?fedora})
-install -m 0644 -D udev/50-rbd.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/50-rbd.rules
-install -m 0644 -D udev/60-ceph-partuuid-workaround.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/60-ceph-partuuid-workaround.rules
-%elif (0%{?rhel} > 0 && 0%{?rhel} < 7)
+install -m 0644 -D udev/50-rbd.rules $RPM_BUILD_ROOT%{_udevrulesdir}/50-rbd.rules
+install -m 0644 -D udev/60-ceph-partuuid-workaround.rules $RPM_BUILD_ROOT%{_udevrulesdir}/60-ceph-partuuid-workaround.rules
+
+%if 0%{?suse_version}
+install -m 0644 -D systemd/udev-rules.d-95-ceph-osd.rules $RPM_BUILD_ROOT%{_udevrulesdir}/95-ceph-osd.rules
+%endif
+
+%if (0%{?rhel} && 0%{?rhel} < 7)
 install -m 0644 -D udev/95-ceph-osd-alt.rules $RPM_BUILD_ROOT/lib/udev/rules.d/95-ceph-osd.rules
 %endif
 
-%if 0%{?suse_version}
-install -m 0644 -D udev/50-rbd.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/50-rbd.rules
-install -m 0644 -D systemd/udev-rules.d-95-ceph-osd.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/95-ceph-osd.rules
+%if (0%{?rhel} && 0%{?rhel} >= 7) || 0%{?fedora}
+install -m 0644 -D udev/95-ceph-osd.rules $RPM_BUILD_ROOT/lib/udev/rules.d/95-ceph-osd.rules
+mv $RPM_BUILD_ROOT/lib/udev/rules.d/95-ceph-osd.rules $RPM_BUILD_ROOT/usr/lib/udev/rules.d/95-ceph-osd.rules
+mv $RPM_BUILD_ROOT/sbin/mount.ceph $RPM_BUILD_ROOT/usr/sbin/mount.ceph
+mv $RPM_BUILD_ROOT/sbin/mount.fuse.ceph $RPM_BUILD_ROOT/usr/sbin/mount.fuse.ceph
 %endif
 
 #set up placeholder directories
@@ -728,20 +738,8 @@ mkdir -p %{_localstatedir}/run/ceph/
 %{_libdir}/rados-classes/libcls_version.so*
 %dir %{_libdir}/ceph/erasure-code
 %{_libdir}/ceph/erasure-code/libec_*.so*
-
-%if 0%{?debian}
-/lib/udev/rules.d/50-rbd.rules
-%endif
-%if 0%{?rhel} >= 7 || 0%{?fedora} || 0%{?suse_version}
-/usr/lib/udev/rules.d/50-rbd.rules
-%endif
-%if 0%{?rhel} >= 7 || 0%{?fedora}
-/usr/lib/udev/rules.d/60-ceph-partuuid-workaround.rules
-/usr/lib/udev/rules.d/95-ceph-osd.rules
-%endif
-%if 0%{?suse_version}
-/usr/lib/udev/rules.d/95-ceph-osd.rules
-%endif
+%{_udevrulesdir}/60-ceph-partuuid-workaround.rules
+%{_udevrulesdir}/95-ceph-osd.rules
 %config %{_sysconfdir}/bash_completion.d/ceph
 %config(noreplace) %{_sysconfdir}/logrotate.d/ceph
 %if 0%{?suse_version}
@@ -820,6 +818,7 @@ mkdir -p %{_localstatedir}/run/ceph/
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{python_sitelib}/ceph_argparse.py*
+%{_udevrulesdir}/50-rbd.rules
 
 %postun -n ceph-common
 # Package removal cleanup


### PR DESCRIPTION
This commit fixes bnc#934343 by making sure 50-rbd.rules is installed in the
right directory and belongs to the ceph-common package.

It also introduces use of %{_udevrulesdir} and makes sure the Red Hat, Fedora,
etc. conditionals do not thwart our fix.

Signed-off-by: Nathan Cutler <ncutler@suse.com>