### PR TITLE
ceph.spec.in: use full radosgw path for set_permissions

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -918,7 +918,7 @@ fi
 %post radosgw
 /sbin/ldconfig
 %if 0%{?suse_version}
-  %set_permissions %{name}
+  %set_permissions %{_bindir}/radosgw
   # TODO: find out what exactly this systemd-tmpfiles inovcation is for
   systemd-tmpfiles --create %{_tmpfilesdir}/ceph-radosgw.conf
   # explicit systemctl daemon-reload (that's the only relevant bit of


### PR DESCRIPTION
The %set_permissions macro expands into a "/usr/bin/chkstat --system"
call, which requires the radosgw binary path as a parameter to take
effect.

Signed-off-by: David Disseldorp <ddiss@suse.de>