### PR TITLE
[DoNotMergeYet] drop permissions of civetweb after startup (alternative approach to bnc#943471)

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1033,7 +1033,7 @@ OPTION(rgw_bucket_quota_cache_size, OPT_INT, 10000) // number of entries in buck
 
 OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Bucket' response header
 
-OPTION(rgw_frontends, OPT_STR, "fastcgi, civetweb port=7480") // rgw front ends
+OPTION(rgw_frontends, OPT_STR, "fastcgi, civetweb port=7480 user=wwwrun") // rgw front ends
 
 OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT, 180) // time period for accumulating modified buckets before syncing stats
 OPTION(rgw_user_quota_sync_interval, OPT_INT, 3600 * 24) // time period for accumulating modified buckets before syncing entire user stats

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -968,10 +968,14 @@ public:
     char thread_pool_buf[32];
     snprintf(thread_pool_buf, sizeof(thread_pool_buf), "%d", (int)g_conf->rgw_thread_pool_size);
     string port_str;
+    string userid;
     map<string, string> conf_map = conf->get_config_map();
     conf->get_val("port", "80", &port_str);
     conf_map.erase("port");
     conf_map["listening_ports"] = port_str;
+    conf->get_val("user", "wwwrun", &userid);
+    conf_map.erase("user");
+    conf_map["run_as_user"] = userid;
     set_conf_default(conf_map, "enable_keep_alive", "yes");
     set_conf_default(conf_map, "num_threads", thread_pool_buf);
     set_conf_default(conf_map, "decode_url", "no");

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -9,7 +9,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --conf /etc/ceph/${CLUSTER}.conf --name client.radosgw.%i
 ExecStartPre=/usr/lib/ceph-radosgw/ceph-radosgw-prestart.sh --cluster ${CLUSTER} --name %i
-User=wwwrun
+User=root
 
 [Install]
 WantedBy=ceph.target


### PR DESCRIPTION
[Marking as DoNotYetMerge - temp solution already exists and would need some rollback, thus we may want to hold off with this until maintenance release]

After chatting with @smithfarm about the spec file approach to this bug, we wanted to look into the possibility that rgw/civetweb had some reasonably painless way to start as root (bind to privileged ports, read root-only ssl certs, etc), then drop permissions after startup. These patches should do just that.

Added is a "user" config option to the civetweb configurable section of rgw_frontends. Original approach was to use a separate "rgw_run_as_user" option, but after discussion with yehudasa (#ceph-devel), this seemed the better approach. Default "user" is set to our wwwrun and can be overridden from ceph.conf.

If anyone is curious to try it out: IBS://home:k_mroz:SES2/ceph

In terms of getting this up-streamed, I believe they will ultimately run daemons under user "ceph". Thus, we would need to maintain a small patch set regardless, or put the logic to set user=wwwrun in ceph-deploy.

Lastly, it would be great to get 2 patches cherry-picked into our civetweb submodule (security related):
    5e753cc: civetweb.c: fix setgroups() -Wimplicit-function-declaration
    a3c460c: call setgroups() to avoid supplemental group leakage

I will also, as a side activity, try to look into doing this from systemd.sockets - per @l-mb.