### PR TITLE
ceph.spec.in: use _smp_ncpus_max to limit _smp_flags in SUSE builds

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -591,6 +591,11 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		%{?_with_tcmalloc} \
 		CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS"
 
+%if 0%{?suse_version}
+%if $RPM_BUILD_NCPUS > 8
+%define _smp_mflags -j8
+%endif
+%endif
 
 make %{?_smp_mflags}
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -592,7 +592,7 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS"
 
 %if 0%{?suse_version}
-%if $RPM_BUILD_NCPUS > 8
+%if 0%{?_smp_ncpus_max} > 8
 %define _smp_mflags -j8
 %endif
 %endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/13858 Fixes: #13858

Signed-off-by: Karol Mroz <kmroz@suse.com>