### PR TITLE
ceph.spec.in: disable udev systemd slices on uninstall

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -675,7 +675,7 @@ rm -rf $RPM_BUILD_ROOT
   %endif
   # Disable and stop on removal.
   if [ $1 = 0 ] ; then
-    SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-'  | cut -d' ' -f1)
+    SERVICE_LIST=$(systemctl | grep -E '^ceph-mon@|^ceph-create-keys@|^ceph-osd@|^ceph-mds@|^ceph-disk-|^system-ceph\\x2' | cut -d' ' -f1)
     if [ -n "$SERVICE_LIST" ]; then
       for SERVICE in $SERVICE_LIST; do
         /usr/bin/systemctl --no-reload disable $SERVICE > /dev/null 2>&1 || :


### PR DESCRIPTION
The "^system-ceph\\x2" regex catches "system-ceph\x2ddisk\x2dactivate"
"system-ceph\x2ddisk\x2dactivate\x2djournal", "system-ceph\x2dosd", etc.
systemd slices spawned by udev.

Signed-off-by: David Disseldorp <ddiss@suse.de>