### PR TITLE
ceph_disk.main: s/get_dev_size/get_free_partition_size/

### DIFF
--- a/src/ceph-disk
+++ b/src/ceph-disk
@@ -408,27 +408,85 @@ def get_dev_relpath(name):
     return name.replace('!', '/')
 
 
-def get_dev_size(dev, size='megabytes'):
+def get_free_partition_size(dev, size='mebibyte'):
     """
-    Attempt to get the size of a device so that we can prevent errors
-    from actions to devices that are smaller, and improve error reporting.
+    Get the last free partition size on a given device.
 
-    Because we want to avoid breakage in case this approach is not robust, we
-    will issue a warning if we failed to get the size.
-
-    :param size: bytes or megabytes
+    :param size: units to calculate size
     :param dev: the device to calculate the size
     """
-    fd = os.open(dev, os.O_RDONLY)
-    dividers = {'bytes': 1, 'megabytes': 1024*1024}
+    parted_unit_map = {
+        'bytes': 'B',
+        'gibibyte': 'GiB',
+        'gigabyte': 'GB',
+        'mebibyte': 'MiB',
+        'megabytes': 'MB',
+    }
+    parted_unit = parted_unit_map.get(size)
+    if parted_unit is None:
+        raise Error('get_free_partition_size argument error')
     try:
-        device_size = os.lseek(fd, 0, os.SEEK_END)
-        divider = dividers.get(size, 1024*1024)  # default to megabytes
-        return device_size/divider
-    except Exception as error:
-        LOG.warning('failed to get size of %s: %s' % (dev, str(error)))
-    finally:
-        os.close(fd)
+        partitions = _check_output(
+
+            args=[
+                'parted',
+                '--machine',
+                '--',
+                dev,
+                'unit',
+                parted_unit,
+                'print',
+                'free'
+            ],
+        )
+    except subprocess.CalledProcessError as e:
+        LOG.info('cannot read partition index; assume it '
+                 'isn\'t present\n (Error: %s)' % e)
+        raise Error('cannot read partition index; assume it '
+                    'isn\'t present\n (Error: %s)' % e)
+    if not partitions:
+        raise Error('parted failed to output anything for %s' % (dev))
+    LOG.debug('get_free_partition_size: analyzing ' + partitions)
+    # Details about the disk
+    device_line = None
+    # Details about the last partition.
+    partion_last_line = None
+    for line in partitions.split('\n'):
+        if len(line) == 0:
+            continue
+        splitline = line.split(':')
+        if len(splitline) == 1:
+            continue
+        if line[0] == '/':
+            device_line = splitline
+            continue
+        partion_last_line = splitline
+    # We set this variable from the data
+    freespace_str_unit = None
+    if partion_last_line is not None:
+        # We have a partion table
+        if len(partion_last_line) < 5:
+            LOG.error('Failed to parse size free space in %s' % (dev))
+            raise Error('Failed to parse size free space in %s' % (dev))
+        if partion_last_line[4] != 'free;':
+            LOG.warning('No free disk space at end of %s' % (dev))
+            return 0
+        freespace_str_unit = partion_last_line[3]
+    if device_line is not None and partion_last_line is None:
+        # We have no partitions
+        LOG.info('No partiiton table for disk %s' % (dev))
+        freespace_str_unit = splitline[1]
+    if freespace_str_unit is None:
+        # We have an issue parsing the output
+        LOG.error('Failed to get size free space in %s' % (dev))
+        raise Error('Failed to get size free space in %s' % (dev))
+    if freespace_str_unit[-len(parted_unit):] != parted_unit:
+        LOG.warning('Failed to get unit size free space in %s' % (dev))
+        raise Error('Failed to get unit size free space in %s' % (dev))
+    # Remove the units, and strip decimal fractions
+    freespace_str = freespace_str_unit[:-len(parted_unit)].split(".")[0]
+    # Return the result cast as a long so we can handle bytes
+    return long(freespace_str)
 
 
 def get_partition_dev(dev, pnum):
@@ -1427,13 +1485,13 @@ def prepare_journal_dev(
             )
         LOG.warning('OSD will not be hot-swappable if journal is not the same device as the osd data')
 
-    dev_size = get_dev_size(journal)
+    dev_size = get_free_partition_size(journal)
 
     if journal_size > dev_size:
         LOG.error('refusing to create journal on %s' % journal)
-        LOG.error('journal size (%sM) is bigger than device (%sM)' % (journal_size, dev_size))
+        LOG.error('journal size (%sM) is bigger than device space (%sM)' % (journal_size, dev_size))
         raise Error(
-            '%s device size (%sM) is not big enough for journal' % (journal, dev_size)
+            '%s device space (%sM) is not big enough for journal' % (journal, dev_size)
         )
 
     try:


### PR DESCRIPTION
The code never needs to know the block device size only the free partion space.

We use parted as the output is consitent across these distributions:

    SUSE Linux Enterprise Server 12 SP1
    openSUSE Leap 42.1 (x86_64)
    Debian GNU/Linux 8.3 (jessie)
    Fedora release 23 (Twenty Three)
    Scientific Linux release 7.2 (Nitrogen)
    Scientific Linux release 6.7 (Carbon)

Backported from bd3832b5de4f3f03aa2449af930d4ad965f8c22b

Signed-off-by: Owen Synge <osynge@suse.com>