### PR TITLE
osd/ReplicatedPG: do not proxy read *and* process op locally

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1805,6 +1805,7 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
   bool can_proxy_read = get_osdmap()->get_up_osd_features() &
     CEPH_FEATURE_OSD_PROXY_FEATURES;
   OpRequestRef promote_op;
+  bool did_proxy_read = false;
 
   switch (pool.info.cache_mode) {
   case pg_pool_t::CACHEMODE_WRITEBACK:
@@ -1832,10 +1833,12 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
       return true;
     }
 
-    if (can_proxy_read)
+    if (can_proxy_read) {
       do_proxy_read(op);
-    else
+      did_proxy_read = true;
+    } else {
       promote_op = op;   // for non-proxy case promote_object needs this
+    }
 
     // Avoid duplicate promotion
     if (obc.get() && obc->is_blocked()) {
@@ -1877,7 +1880,7 @@ bool ReplicatedPG::maybe_handle_cache(OpRequestRef op,
 	promote_object(obc, missing_oid, oloc, promote_op);
       } else {
 	// not promoting
-	return false;
+	return did_proxy_read;
       }
       break;
     }


### PR DESCRIPTION
If we proxy the read, we cannot return false, even if we fail to also
trigger a promotion; (bnc#971768).

Fixes: http://tracker.ceph.com/issues/15171
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 7eae05e14231cb3476d14bf74b15bf9646849d09)