### PR TITLE
Revert "rbd: update default image features"

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -197,16 +197,6 @@ Upgrading from Infernalis or Hammer
 
 * The 'ceph mds setmap' command has been removed.
 
-* The default RBD image features for new images have been updated to
-  enable the following: exclusive lock, object map, fast-diff, and
-  deep-flatten. These features are not currently supported by the RBD
-  kernel driver nor older RBD clients. They can be disabled on a per-image
-  basis via the RBD CLI, or the default features can be updated to the
-  pre-Jewel setting by adding the following to the client section of the Ceph
-  configuration file::
-
-    rbd default features = 1
-
 * The rbd legacy image format (version 1) is deprecated with the Jewel
   release.
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1190,11 +1190,9 @@ OPTION(rbd_default_format, OPT_INT, 2)
 OPTION(rbd_default_order, OPT_INT, 22)
 OPTION(rbd_default_stripe_count, OPT_U64, 0) // changing requires stripingv2 feature
 OPTION(rbd_default_stripe_unit, OPT_U64, 0) // changing to non-object size requires stripingv2 feature
-OPTION(rbd_default_features, OPT_INT, 61)   // only applies to format 2 images
-					    // +1 for layering, +2 for stripingv2,
-					    // +4 for exclusive lock, +8 for object map
-					    // +16 for fast-diff, +32 for deep-flatten,
-					    // +64 for journaling
+OPTION(rbd_default_features, OPT_INT, 3) // only applies to format 2 images
+					 // +1 for layering, +2 for stripingv2,
+					 // +4 for exclusive lock, +8 for object map
 
 OPTION(rbd_default_map_options, OPT_STR, "") // default rbd map -o / --options
 

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -142,7 +142,7 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
 
                     expected_features = features
                     if expected_features is None or format == 1:
-                        expected_features = 0 if format == 1 else 61
+                        expected_features = 0 if format == 1 else 3
                     eq(expected_features, image.features())
 
                     expected_stripe_count = stripe_count


### PR DESCRIPTION
This reverts commit d24883e4973ae13c50137cf35bdba12bf67d7860.
Use defaults that are compatible with the current Linux kernel RBD
client.

Acked-by: David Disseldorp <ddiss@suse.de>