### PR TITLE
rgw: remove -EEXIST error msg for ZoneCreate

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1507,7 +1507,6 @@ int RGWZoneParams::create(bool exclusive)
 
   r = RGWSystemMetaObj::create(exclusive);
   if (r < 0) {
-    ldout(cct, 0) << "RGWZoneParams::create(): error creating default zone params: " << cpp_strerror(-r) << dendl;
     return r;
   }
 


### PR DESCRIPTION
currently for any admin operations like user create etc. you would
always see:

`RGWZoneParams::create(): error creating default zone params: (17) File
Exists`

in stdout as the debug level is set to 0, which doesn't make much sense
for an end user, so skip the error message, callers of the function handle
the error message anyway, so we skip it here

Fixes: http://tracker.ceph.com/issues/15720
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>
(cherry picked from commit 2ace9d7f349ef09d3ed87fb216cda3e305ef706f)