### PR TITLE
Fix for bsc#982324

### DIFF
--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -11,10 +11,6 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
-PrivateDevices=yes
-ProtectHome=true
-ProtectSystem=full
-PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -15,7 +15,6 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -21,7 +21,6 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -17,10 +17,6 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
-PrivateDevices=yes
-ProtectHome=true
-ProtectSystem=full
-PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -15,7 +15,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -12,9 +12,6 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
-ProtectHome=true
-ProtectSystem=full
-PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -10,10 +10,6 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
-PrivateDevices=yes
-ProtectHome=true
-ProtectSystem=full
-PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30s
 StartLimitBurst=5

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -14,7 +14,6 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30s
 StartLimitBurst=5

--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -17,7 +17,6 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
-TasksMax=infinity
 
 [Install]
 WantedBy=ceph-rbd-mirror.target


### PR DESCRIPTION
This fixes https://bugzilla.suse.com/show_bug.cgi?id=982324 by reverting the commits that add the unsupported lvalues to the systemd unit files.