### PR TITLE
rpm: build of ceph-test package disabled by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,11 +33,13 @@ install-data-local::
 	-install -m 600 share/id_dsa_drop.ceph.com.pub $(DESTDIR)$(datadir)/ceph/id_dsa_drop.ceph.com.pub
 
 all-local::
+if WITH_TESTS
 if WITH_DEBUG
 #	We need gtest to build the rados-api tests. We only build those in
 #	a debug build, though.
 	@cd src/gmock/gtest && $(MAKE) $(AM_MAKEFLAGS) lib/libgtest.la lib/libgtest_main.la
 	@cd src/gmock && $(MAKE) $(AM_MAKEFLAGS) lib/libgmock.la lib/libgmock_main.la
+endif
 endif
 
 CHECK_ULIMIT := true

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -730,7 +730,6 @@ rm -rf %{buildroot}
 %{_bindir}/ceph-run
 %{_bindir}/ceph-dencoder
 %{_bindir}/ceph-detect-init
-%{_bindir}/ceph-client-debug
 %{_bindir}/cephfs
 %{_bindir}/cephfs-data-scan
 %{_bindir}/cephfs-journal-tool
@@ -1346,6 +1345,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 #################################################################################
 %files -n ceph-test
 %defattr(-,root,root,-)
+%{_bindir}/ceph-client-debug
 %{_bindir}/ceph_bench_log
 %{_bindir}/ceph_kvstorebench
 %{_bindir}/ceph_multi_stress_watch

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -13,7 +13,7 @@
 #
 # Please submit bugfixes or comments via http://tracker.ceph.com/
 # 
-%bcond_with tests
+%bcond_with make_check
 %bcond_with xio
 %bcond_without tcmalloc
 %bcond_with lowmem_builder
@@ -660,7 +660,7 @@ fi
 
 make "$PARALLEL_BUILD"
 
-%if 0%{with tests}
+%if 0%{with make_check}
 %check
 # run in-tree unittests
 make CHECK_ULIMIT=false %{?_smp_mflags} check

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -13,6 +13,11 @@
 #
 # Please submit bugfixes or comments via http://tracker.ceph.com/
 # 
+%if 0%{?suse_version}
+%bcond_with ceph_test_package
+%else
+%bcond_without ceph_test_package
+%endif
 %bcond_with make_check
 %bcond_with xio
 %bcond_without tcmalloc
@@ -509,6 +514,7 @@ Obsoletes:	python-ceph < %{version}-%{release}
 This package contains Python libraries for interacting with Cephs distributed
 file system.
 
+%if 0%{with ceph_test_package}
 %package -n ceph-test
 Summary:	Ceph benchmarks and test tools
 Group:		System Environment/Libraries
@@ -517,6 +523,7 @@ Requires:	ceph-common
 Requires:	xmlstarlet
 %description -n ceph-test
 This package contains Ceph benchmarks and test tools.
+%endif
 
 %if 0%{with cephfs_java}
 
@@ -611,6 +618,9 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--with-nss \
 		--without-cryptopp \
 		--with-debug \
+%if 0%{without ceph_test_package}
+                --without-tests \
+%endif
 %if 0%{with cephfs_java}
 		--enable-cephfs-java \
 %endif
@@ -1343,6 +1353,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{python_sitelib}/ceph_volume_client.py*
 
 #################################################################################
+%if 0%{with ceph_test_package}
 %files -n ceph-test
 %defattr(-,root,root,-)
 %{_bindir}/ceph-client-debug
@@ -1379,6 +1390,7 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{_mandir}/man8/ceph-debugpack.8*
 %dir %{_libdir}/ceph
 %{_libdir}/ceph/ceph-monstore-update-crush.sh
+%endif
 
 #################################################################################
 %if 0%{with cephfs_java}

--- a/configure.ac
+++ b/configure.ac
@@ -488,6 +488,13 @@ AC_ARG_WITH([debug],
             [with_debug=no])
 AM_CONDITIONAL(WITH_DEBUG, test "$with_debug" = "yes")
 
+# exclude ceph-test files from build?
+AC_ARG_WITH([tests],
+            [AS_HELP_STRING([--without-tests], [disable the build of ceph-test package scripts/binaries])],
+            [],
+            [with_tests=yes])
+AM_CONDITIONAL(WITH_TESTS, test "$with_tests" = "yes")
+
 AC_DEFINE([DEBUG_GATHER], [1], [Define if you want C_Gather debugging])
 
 # code coverage?

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,7 +3,6 @@ EXTRA_DIST = \
 	man/8/ceph-clsinfo.rst	\
 	man/8/ceph-conf.rst	\
 	man/8/ceph-create-keys.rst	\
-	man/8/ceph-debugpack.rst	\
 	man/8/ceph-dencoder.rst	\
 	man/8/ceph-deploy.rst	\
 	man/8/ceph-detect-init.rst	\
@@ -35,3 +34,7 @@ EXTRA_DIST = \
 	man/8/rbd-replay.rst	\
 	man/8/rbd.rst           \
 	man/8/rbdmap.rst
+
+if WITH_TESTS
+EXTRA_DIST += man/8/ceph-debugpack.rst
+endif

--- a/man/Makefile-server.am
+++ b/man/Makefile-server.am
@@ -4,8 +4,11 @@ dist_man_MANS += \
 	ceph-run.8 \
 	mount.ceph.8 \
 	ceph-create-keys.8 \
-	ceph-rest-api.8 \
-	ceph-debugpack.8
+	ceph-rest-api.8
+
+if WITH_TESTS
+dist_man_MANS += ceph-debugpack.8
+endif
 
 if WITH_SELINUX
 dist_man_MANS += \

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -44,8 +44,10 @@ export VERBOSE = true
 export PYTHONPATH=$(top_srcdir)/src/pybind
 
 # when doing a debug build, make sure to make the targets
+if WITH_TESTS
 if WITH_DEBUG
 bin_PROGRAMS += $(bin_DEBUGPROGRAMS)
+endif
 endif
 
 

--- a/src/Makefile-server.am
+++ b/src/Makefile-server.am
@@ -3,14 +3,17 @@ ceph_sbin_SCRIPTS = ceph-create-keys
 bin_SCRIPTS += \
 	ceph-run \
 	ceph-rest-api \
-	ceph-debugpack \
 	ceph-crush-location
 
 python_PYTHON += pybind/ceph_rest_api.py
 
+if WITH_TESTS
+
 shell_scripts += ceph-coverage
 
-bin_SCRIPTS += ceph-coverage
+bin_SCRIPTS += ceph-coverage ceph-debugpack
+
+endif
 
 BUILT_SOURCES += init-ceph
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,7 +106,6 @@ EXTRA_DIST += \
 	$(srcdir)/make_version \
 	$(srcdir)/.git_version \
 	$(srcdir)/ceph-rbdnamer \
-	$(srcdir)/tools/ceph-monstore-update-crush.sh \
 	$(srcdir)/script/subman \
 	$(srcdir)/upstart/ceph-all.conf \
 	$(srcdir)/upstart/ceph-disk.conf \
@@ -137,6 +136,10 @@ EXTRA_DIST += \
 	rbdmap \
 	etc-rbdmap \
 	yasm-wrapper
+
+if WITH_TESTS
+EXTRA_DIST += $(srcdir)/tools/ceph-monstore-update-crush.sh
+endif
 
 EXTRA_DIST += \
 	unittest_bufferlist.sh

--- a/src/tools/Makefile-server.am
+++ b/src/tools/Makefile-server.am
@@ -13,7 +13,9 @@ bin_DEBUGPROGRAMS += ceph-kvstore-tool
 
 if WITH_MON
 ceph_monstore_update_crushdir = $(libdir)/ceph
+if WITH_TESTS
 ceph_monstore_update_crush_SCRIPTS = tools/ceph-monstore-update-crush.sh
+endif
 endif
 
 if WITH_OSD


### PR DESCRIPTION
With the changes in this PR, the build of the ceph-test package is disabled by default when building the RPMs for the SUSE distros.

Signed-off-by: Ricardo Dias <rdias@suse.com>