### PR TITLE
DNM: spec: add ssl requirements

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -165,10 +165,11 @@ BuildRequires:	lttng-ust-devel
 BuildRequires:  babeltrace-devel
 %endif
 %endif
-# expat and fastcgi for RGW
+# expat, fastcgi and openssl for RGW
 %if 0%{?suse_version}
 BuildRequires:	libexpat-devel
 BuildRequires:	FastCGI-devel
+BuildRequires:  openssl-devel
 %endif
 %if 0%{?rhel} || 0%{?fedora}
 BuildRequires:	expat-devel

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -131,7 +131,7 @@ libcivetweb_la_SOURCES =  \
 	rgw/rgw_civetweb_log.cc \
 	civetweb/src/civetweb.c
 
-libcivetweb_la_CXXFLAGS = ${CIVETWEB_INCLUDE} -fPIC -Woverloaded-virtual \
+libcivetweb_la_CXXFLAGS = ${CIVETWEB_INCLUDE} -fPIC -DNO_SSL_DL -Woverloaded-virtual \
 	${AM_CXXFLAGS}
 libcivetweb_la_CFLAGS = -I$(srcdir)/civetweb/include ${CIVETWEB_INCLUDE} -fPIC -DNO_SSL_DL
 LIBCIVETWEB_DEPS += -lssl -lcrypto


### PR DESCRIPTION
Needed to directly link ssl and crypto libraries for civetweb and rgw.
Fixes bsc#942874, bsc#990438

(cherry picked from commit 1f0d1c151097f18384ac4db96c98a22ead9cb7a0)
Signed-off-by: Karol Mroz <kmroz@suse.de>

Conflicts:
  ceph.spec.in
    BuildRequires moved out to separate section.