### PR TITLE
rgw ldap: enforce simple_bind w/LDAPv3

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -63,7 +63,8 @@ License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-auto
 Group:         System/Filesystems
 %endif
 URL:		http://ceph.com/
-Source0:	http://ceph.com/download/%{name}-%{version}.tar.bz2
+Source0:	%{name}-%{version}.tar.bz2
+Source99:       ceph-rpmlintrc
 #################################################################################
 # dependencies that apply across all distro families
 #################################################################################

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -65,6 +65,7 @@ Group:         System/Filesystems
 URL:		http://ceph.com/
 Source0:	%{name}-%{version}.tar.bz2
 Source99:       ceph-rpmlintrc
+ExclusiveArch:  x86_64 aarch64
 #################################################################################
 # dependencies that apply across all distro families
 #################################################################################

--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -70,14 +70,22 @@ namespace rgw {
 	(void) init();
 	return bind();
       }
+      return -EINVAL;
     }
 
     int simple_bind(const char *dn, const std::string& pwd) {
       LDAP* tldap;
       int ret = ldap_initialize(&tldap, uri.c_str());
-      ret = ldap_simple_bind_s(tldap, dn, pwd.c_str());
       if (ret == LDAP_SUCCESS) {
-	(void) ldap_unbind(tldap);
+	unsigned long ldap_ver = LDAP_VERSION3;
+	ret = ldap_set_option(ldap, LDAP_OPT_PROTOCOL_VERSION,
+			      (void*) &ldap_ver);
+	if (ret == LDAP_SUCCESS) {
+	  ret = ldap_simple_bind_s(tldap, dn, pwd.c_str());
+	  if (ret == LDAP_SUCCESS) {
+	    (void) ldap_unbind(tldap);
+	  }
+	}
       }
       return ret; // OpenLDAP client error space
     }


### PR DESCRIPTION
Found by Harald Klein <hklein@redhat.com>.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
(cherry picked from commit 08d54291435e4d1cb5e02cda3951bc6e8510b0e2)

This should fix the rpm lint warning preventing kraken from properly building in OBS.