### PR TITLE
ceph.spec.in: nuke sources at end of %install phase

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -724,6 +724,11 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-osd
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 
+# hack to reduce disk space usage in OBS
+%if 0%{?is_opensuse}
+rm -rf .
+%endif
+
 %clean
 rm -rf %{buildroot}
 


### PR DESCRIPTION
Dominique Leuenberger / DimStar wrote:

The only idea I would have in plus for now (which is a really crude
hack) would be as last commands in %install:
rm -rf . (which basically removes all the sources and certainly gains
some space)

This would work, as the files have all been copied to %{buildroot} by
that time and - debuginfo is not split at this moment, which is what
occupies some more space later on - and the fact that 'build' will
attempt to install the built binaries.

Signed-off-by: Nathan Cutler <ncutler@suse.com>