### PR TITLE
ceph.spec.in: ceph-devel-compat drop ceph dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -473,7 +473,6 @@ Group:		Development/Libraries
 License:	LGPL-2.0
 Provides:	ceph-devel = %{version}-%{release}
 Obsoletes:	ceph-devel < %{version}-%{release}
-Requires:	%{name} = %{version}-%{release}
 Requires:	librados2-devel = %{version}-%{release}
 Requires:	libradosstriper1-devel = %{version}-%{release}
 Requires:	librbd1-devel = %{version}-%{release}


### PR DESCRIPTION
This run-time dependency on the ceph package is most likely bogus.

Signed-off-by: Nathan Cutler <ncutler@suse.com>