### PR TITLE
ceph.spec.in: drop ceph-rpmlintrc source line

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -438,7 +438,7 @@ Summary:	Python 3 libraries for the RADOS object store
 Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	python%{python3_pkgversion}
-Requires:	librados2 = %{epoch}:%{version}-%{release}
+Requires:	librados2 = %{version}-%{release}
 %description -n python%{python3_pkgversion}-rados
 This package contains Python 3 libraries for interacting with Cephs RADOS
 object store.
@@ -508,8 +508,8 @@ block device.
 Summary:	Python 3 libraries for the RADOS block device
 Group:		System Environment/Libraries
 License:	LGPL-2.0
-Requires:	librbd1 = %{epoch}:%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
+Requires:	librbd1 = %{version}-%{release}
+Requires:	python%{python3_pkgversion}-rados = %{version}-%{release}
 %description -n python%{python3_pkgversion}-rbd
 This package contains Python 3 libraries for interacting with Cephs RADOS
 block device.
@@ -556,8 +556,8 @@ file system.
 Summary:	Python 3 libraries for Ceph distributed file system
 Group:		System Environment/Libraries
 License:	LGPL-2.0
-Requires:	libcephfs1 = %{epoch}:%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
+Requires:	libcephfs1 = %{version}-%{release}
+Requires:	python%{python3_pkgversion}-rados = %{version}-%{release}
 %description -n python%{python3_pkgversion}-cephfs
 This package contains Python 3 libraries for interacting with Cephs distributed
 file system.
@@ -642,9 +642,9 @@ Summary:	Compatibility package for Cephs python libraries
 Group:		System Environment/Libraries
 License:	LGPL-2.0
 Obsoletes:	python-ceph
-Requires:	python-rados = %{epoch}:%{version}-%{release}
-Requires:	python-rbd = %{epoch}:%{version}-%{release}
-Requires:	python-cephfs = %{epoch}:%{version}-%{release}
+Requires:	python-rados = %{version}-%{release}
+Requires:	python-rbd = %{version}-%{release}
+Requires:	python-cephfs = %{version}-%{release}
 Provides:	python-ceph
 %description -n python-ceph-compat
 This is a compatibility package to accommodate python-ceph split into

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -75,7 +75,7 @@ Group:         System/Filesystems
 %endif
 URL:		http://ceph.com/
 Source0:	%{name}-%{version}.tar.bz2
-Source99:	ceph-rpmlintrc
+# _insert_obs_source_lines_here
 %if 0%{?suse_version}
 %if 0%{?is_opensuse}
 ExclusiveArch:  x86_64 aarch64 ppc64 ppc64le


### PR DESCRIPTION
We need to get the `Source99: ceph-rpmlintrc` line out of ceph.spec.in because the teuthology buildpackages task chokes on it (the ceph-rpmlintrc file is only in OBS/IBS, not in git):

```
error: Bad file: /tmp/release/SUSE_LINUX/WORKDIR/SOURCES/ceph-rpmlintrc: No such file or directory
```

Replace this line with a comment. The file is needed in OBS/IBS, and the Factory/SLE spec file validation scripts will whine without the spec-file line, but they don't care *which* spec file it is in :-) So we accompany this with a small patch to pre_checkin.sh to add the line to ceph-test.spec.

