### PR TITLE
AArch64: Detect crc32 extension support from assembler

### DIFF
--- a/m4/ax_arm.m4
+++ b/m4/ax_arm.m4
@@ -26,12 +26,19 @@ AC_DEFUN([AX_ARM_FEATURES],
         AC_DEFINE(HAVE_NEON,,[Support NEON instructions])
         AC_SUBST(ARM_NEON_FLAGS)
       fi
-      AX_CHECK_COMPILE_FLAG(-march=armv8-a+crc, ax_cv_support_crc_ext=yes, [])
+
+      AC_LANG_SAVE
+      AC_LANG_CPLUSPLUS
+      AC_CACHE_CHECK(whether the assembler supports crc extensions,
+                     ax_cv_support_crc_ext, AC_TRY_COMPILE([
+          #define CRC32CX(crc, value) __asm__("crc32cx %w[c], %w[c], %x[v]":[c]"+r"(crc):[v]"r"(value))
+          asm(".arch_extension crc");
+          unsigned int foo(unsigned int ret) {
+              CRC32CX(ret, 0);
+              return ret;
+          }],[ foo(0); ], ax_cv_support_crc_ext=yes, []))
       if test x"$ax_cv_support_crc_ext" = x"yes"; then
-        ARM_ARCH_FLAGS="$ARM_ARCH_FLAGS+crc"
-        ARM_CRC_FLAGS="-march=armv8-a+crc -DARCH_AARCH64"
         AC_DEFINE(HAVE_ARMV8_CRC,,[Support ARMv8 CRC instructions])
-        AC_SUBST(ARM_CRC_FLAGS)
       fi
         ARM_FLAGS="$ARM_ARCH_FLAGS $ARM_DEFINE_FLAGS"
     ;;

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -144,7 +144,7 @@ noinst_LTLIBRARIES += libcommon_crc.la
 
 if HAVE_ARMV8_CRC
 libcommon_crc_aarch64_la_SOURCES = common/crc32c_aarch64.c
-libcommon_crc_aarch64_la_CFLAGS = $(AM_CFLAGS) $(ARM_CRC_FLAGS)
+libcommon_crc_aarch64_la_CFLAGS = $(AM_CFLAGS) $(ARM_ARCH_FLAGS)
 LIBCOMMON_DEPS += libcommon_crc_aarch64.la
 noinst_LTLIBRARIES += libcommon_crc_aarch64.la
 endif

--- a/src/common/crc32c_aarch64.c
+++ b/src/common/crc32c_aarch64.c
@@ -2,6 +2,9 @@
 #include "include/int_types.h"
 #include "common/crc32c_aarch64.h"
 
+/* Request crc extension capabilities from the assembler */
+asm(".arch_extension crc");
+
 #define CRC32CX(crc, value) __asm__("crc32cx %w[c], %w[c], %x[v]":[c]"+r"(crc):[v]"r"(value))
 #define CRC32CW(crc, value) __asm__("crc32cw %w[c], %w[c], %w[v]":[c]"+r"(crc):[v]"r"(value))
 #define CRC32CH(crc, value) __asm__("crc32ch %w[c], %w[c], %w[v]":[c]"+r"(crc):[v]"r"(value))


### PR DESCRIPTION
The used compiler may or may not be recent enough to recognize the
crc32 extended cpu type. However, it does not really have to know about
them either, since all we do is pass inline assembly instructions to
the assembler.

This patch moves the crc cpu extension detection from compiler based
to assembler based, so that we can build optimized code even when the
compiler does not know about the cpu type yet.

Signed-off-by: Alexander Graf <agraf@suse.de>