### PR TITLE
rgw: fix for bucket delete racing with mdlog sync

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2203,6 +2203,14 @@ void RGWDeleteBucket::execute()
   }
 
   op_ret = store->delete_bucket(s->bucket, ot);
+
+  if (op_ret == -ECANCELED) {
+    // lost a race, either with mdlog sync or another delete bucket operation.
+    // in either case, we've already called rgw_unlink_bucket()
+    op_ret = 0;
+    return;
+  }
+
   if (op_ret == 0) {
     op_ret = rgw_unlink_bucket(store, s->user->user_id, s->bucket.tenant,
 			       s->bucket.name, false);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17698

Signed-off-by: Casey Bodley <cbodley@redhat.com>
(cherry picked from commit e9cf41f9bfd1aa7d35f945f6a3ee6bb66c135bad)

(Cherry-picked from upstream master PR https://github.com/ceph/ceph/pull/11648 which hasn't been merged yet.)