### PR TITLE
tests: adapt rbd CLI help test for SES3/4

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -158,8 +158,8 @@
     --order arg               object order [12 <= order <= 25]
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
-                              [layering(+), striping, exclusive-lock(+*),
-                              object-map(+*), fast-diff(+*), deep-flatten(+-),
+                              [layering(+), striping(+), exclusive-lock(*),
+                              object-map(*), fast-diff(*), deep-flatten(-),
                               journaling(*)]
     --image-shared            shared image
     --stripe-unit arg         stripe unit
@@ -202,8 +202,8 @@
     --order arg                  object order [12 <= order <= 25]
     --object-size arg            object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg          image features
-                                 [layering(+), striping, exclusive-lock(+*),
-                                 object-map(+*), fast-diff(+*), deep-flatten(+-),
+                                 [layering(+), striping(+), exclusive-lock(*),
+                                 object-map(*), fast-diff(*), deep-flatten(-),
                                  journaling(*)]
     --image-shared               shared image
     --stripe-unit arg            stripe unit
@@ -245,8 +245,8 @@
     --order arg               object order [12 <= order <= 25]
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
-                              [layering(+), striping, exclusive-lock(+*),
-                              object-map(+*), fast-diff(+*), deep-flatten(+-),
+                              [layering(+), striping(+), exclusive-lock(*),
+                              object-map(*), fast-diff(*), deep-flatten(-),
                               journaling(*)]
     --image-shared            shared image
     --stripe-unit arg         stripe unit
@@ -493,8 +493,8 @@
     --order arg               object order [12 <= order <= 25]
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
-                              [layering(+), striping, exclusive-lock(+*),
-                              object-map(+*), fast-diff(+*), deep-flatten(+-),
+                              [layering(+), striping(+), exclusive-lock(*),
+                              object-map(*), fast-diff(*), deep-flatten(-),
                               journaling(*)]
     --image-shared            shared image
     --stripe-unit arg         stripe unit


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=978423
https://build.suse.de/package/show/Devel:Storage:4.0:Staging:Testing/ceph

In SES3/4 we are carrying downstream commit
8aee8db140bcbd1ffd2a7b571dbbade10bec9de3 which causes "make check" to fail at
src/test/cli/rbd/help.t with output like:

```
   --image-feature arg       image features
-                            [layering(+), striping, exclusive-lock(+*),
-                            object-map(+*), fast-diff(+*), deep-flatten(+-),
+                            [layering(+), striping(+), exclusive-lock(*),
+                            object-map(*), fast-diff(*), deep-flatten(-),
                             journaling(*)]
```

This commit adapts the test to match the actual rbd help output.

Signed-off-by: smithfarm <ncutler@suse.com>