### PR TITLE
ceph.spec.in: make check only in ceph-test package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -702,7 +702,7 @@ fi
 
 make "$PARALLEL_BUILD"
 
-%if 0%{with make_check}
+%if 0%{with make_check} && 0%{with ceph_test_package}
 %check
 # run in-tree unittests
 make CHECK_ULIMIT=false %{?_smp_mflags} check


### PR DESCRIPTION
I don't know for sure, but it seems reasonable to assume that the tests in
"make check" expect the binaries from ceph-test to be built.

Signed-off-by: Nathan Cutler <ncutler@suse.com>