### PR TITLE
rpm: expand log file ownership change

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1032,8 +1032,7 @@ usermod -c "Ceph storage service" \
         ceph
 # fix ownership of log files
 [ -d /var/log/ceph ] || exit 0
-[ "$(stat -c %U /var/log/ceph)" = "ceph" ] && exit 0
-find /var/log/ceph -type f -name '*.log' -exec chown ceph.ceph {} \;
+find /var/log/ceph -type f -name '*.log*' -exec chown ceph.ceph {} \;
 chown ceph.ceph /var/log/ceph
 %endif
 exit 0


### PR DESCRIPTION
Here we are trying to be helpful on upgrade by ensuring that log files are
owned by the ceph user, but it turns out we were being too cautious. The
/var/log/ceph directory might not be owned by ceph and the log files might have
names like foo.log-20151215

References: https://bugzilla.suse.com/show_bug.cgi?id=1010930#c13
Signed-off-by: Nathan Cutler <ncutler@suse.com>