### PR TITLE
Revert "rpm: fix ownership of logfiles in %pre"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1030,10 +1030,6 @@ usermod -c "Ceph storage service" \
         -g ceph \
         -s /sbin/nologin \
         ceph
-# fix ownership of log files
-[ -d /var/log/ceph ] || exit 0
-find /var/log/ceph -type f -name '*.log*' -exec chown ceph.ceph {} \;
-chown ceph.ceph /var/log/ceph
 %endif
 exit 0
 
@@ -1274,15 +1270,6 @@ fi
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target
-
-%pre radosgw
-%if 0%{?suse_version}
-# fix ownership of log files
-[ -d /var/log/ceph-radosgw ] || exit 0
-[ "$(stat -c %U /var/log/ceph-radosgw)" = "ceph" ] && exit 0
-find /var/log/ceph-radosgw -type f -name '*.log' -exec chown ceph.ceph {} \;
-chown ceph.ceph /var/log/ceph-radosgw
-%endif
 
 %post radosgw
 %if 0%{?suse_version}


### PR DESCRIPTION
This reverts commits 30000255973986169ca9162f9e92cb5a78fa7015 and
eb81424461ee4cdfad11bde44eab92e36f2ca62e and brings this section
of the spec file into line with upstream.

Signed-off-by: Nathan Cutler <ncutler@suse.com>