### PR TITLE
rpm: expand log file reown for ceph-radosgw

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1125,8 +1125,7 @@ fi
 %if 0%{?suse_version}
 # fix ownership of log files
 [ -d /var/log/ceph-radosgw ] || exit 0
-[ "$(stat -c %U /var/log/ceph-radosgw)" = "ceph" ] && exit 0
-find /var/log/ceph-radosgw -type f -name '*.log' -exec chown ceph.ceph {} \;
+find /var/log/ceph-radosgw -type f -name '*.log*' -exec chown ceph.ceph {} \;
 chown ceph.ceph /var/log/ceph-radosgw
 %endif
 


### PR DESCRIPTION
Analogous change to d8f5376fef0cc0e0fb492651e85650a240e5b63f

Signed-off-by: Nathan Cutler <ncutler@suse.com>