### PR TITLE
tests: wget test code directly from github

### DIFF
--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -1,8 +1,9 @@
 #!/bin/sh -ex
 
 CEPH_REF=${CEPH_REF:-master}
-wget -O test_cephfs.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_cephfs.py" || \
-    wget -O test_cephfs.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_cephfs.py"
+wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/src/test/pybind/test_cephfs.py
+#wget -O test_cephfs.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_cephfs.py" || \
+#    wget -O test_cephfs.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_cephfs.py"
 
 # Running as root because the filesystem root directory will be
 # owned by uid 0, and that's where we're writing.

--- a/qa/workunits/rados/test_python.sh
+++ b/qa/workunits/rados/test_python.sh
@@ -1,8 +1,8 @@
 #!/bin/sh -ex
 
 CEPH_REF=${CEPH_REF:-master}
-#wget -q https://raw.github.com/ceph/ceph/$CEPH_REF/src/test/pybind/test_rados.py
-wget -O test_rados.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_rados.py" || \
-    wget -O test_rados.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_rados.py"
+wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/src/test/pybind/test_rados.py
+#wget -O test_rados.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_rados.py" || \
+#    wget -O test_rados.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_rados.py"
 ${PYTHON:-python} -m nose -v test_rados
 exit 0

--- a/qa/workunits/rbd/notify_master.sh
+++ b/qa/workunits/rbd/notify_master.sh
@@ -1,7 +1,8 @@
 #!/bin/sh -ex
 
 CEPH_REF=${CEPH_REF:-master}
-wget -O test_notify.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/test_notify.py"
+wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/src/test/pybind/test_notify.py
+#wget -O test_notify.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/test_notify.py"
 
 python test_notify.py master
 exit 0

--- a/qa/workunits/rbd/notify_slave.sh
+++ b/qa/workunits/rbd/notify_slave.sh
@@ -1,7 +1,8 @@
 #!/bin/sh -ex
 
 CEPH_REF=${CEPH_REF:-master}
-wget -O test_notify.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/test_notify.py"
+wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/src/test/pybind/test_notify.py
+#wget -O test_notify.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/test_notify.py"
 
 python test_notify.py slave
 exit 0

--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -8,7 +8,8 @@
 #
 
 if [ -n "${CEPH_REF}" ]; then
-  wget -O rbd_mirror_helpers.sh "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=qa/workunits/rbd/rbd_mirror_helpers.sh"
+  wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/qa/workunits/rbd/rbd_mirror_helpers.sh
+  #wget -O rbd_mirror_helpers.sh "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=qa/workunits/rbd/rbd_mirror_helpers.sh"
   . ./rbd_mirror_helpers.sh
 else
   . $(dirname $0)/rbd_mirror_helpers.sh

--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -12,7 +12,8 @@ IMAGE_COUNT=50
 export LOCKDEP=0
 
 if [ -n "${CEPH_REF}" ]; then
-  wget -O rbd_mirror_helpers.sh "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=qa/workunits/rbd/rbd_mirror_helpers.sh"
+  wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/qa/workunits/rbd/rbd_mirror_helpers.sh
+  #wget -O rbd_mirror_helpers.sh "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=qa/workunits/rbd/rbd_mirror_helpers.sh"
   . ./rbd_mirror_helpers.sh
 else
   . $(dirname $0)/rbd_mirror_helpers.sh

--- a/qa/workunits/rbd/test_librbd_python.sh
+++ b/qa/workunits/rbd/test_librbd_python.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -ex
 
 CEPH_REF=${CEPH_REF:-master}
-#wget -q https://raw.github.com/ceph/ceph/$CEPH_REF/src/test/pybind/test_rbd.py
-wget -O test_rbd.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_rbd.py" || \
-    wget -O test_rbd.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_rbd.py"
+wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/src/test/pybind/test_rbd.py
+#wget -O test_rbd.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_rbd.py" || \
+#    wget -O test_rbd.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_rbd.py"
 
 if [ -n "${VALGRIND}" ]; then
   valgrind --tool=${VALGRIND} --suppressions=${TESTDIR}/valgrind.supp \

--- a/qa/workunits/rbd/test_lock_fence.sh
+++ b/qa/workunits/rbd/test_lock_fence.sh
@@ -6,7 +6,8 @@ LOCKID=rbdrw
 RBDRW=rbdrw.py
 CEPH_REF=${CEPH_REF:-master}
 
-wget -O $RBDRW "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/rbdrw.py"
+wget -q https://raw.githubusercontent.com/SUSE/ceph/$CEPH_REF/src/test/librbd/$RBDRW
+#wget -O $RBDRW "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/librbd/rbdrw.py"
 
 rbd create $IMAGE --size 10 --image-format 2 --image-shared || exit 1
 


### PR DESCRIPTION
... because downstream SHA1s are available only from github.

In the past, upstream was wgetting lots of stuff directly from github for their
automated integration testing. This turned out to be not so good, because
github would often time out or be unavailable.

To fix this, upstream started maintaining a mirror of the main github repo at
git.ceph.com.

While this mirror is accessible from anywhere, it does not have the downstream
SHA1s that we are testing, so the wget fails.

To fix this, revert to downloading directly from github (hoping that it will
work) and use SUSE/ceph.git instead of ceph/ceph.git.

Also, raw.github.com forwards to raw.githubusercontent, so avoid one redirect.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1000105
Signed-off-by: Jan Fajerski <jfajerski@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit f749ee89cae6b577005df1b5ab8166367133d20f)
Signed-off-by: Jan Fajerski <jfajerski@suse.com>