### PR TITLE
Tweak ceph.spec for ppc64le and s390(x) client build

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -46,7 +46,9 @@
 # LTTng-UST enabled on Fedora, RHEL 6+, and SLE (not openSUSE)
 %if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?suse_version}
 %if ! 0%{?is_opensuse}
+%ifarch aarch64 x86_64
 %bcond_without lttng
+%endif
 %endif
 %endif
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -22,9 +22,11 @@
 %ifnarch ppc64 ppc64le s390 s390x
 %bcond_without tcmalloc
 %bcond_without xio
+%bcond_without valgrind_devel
 %else
 %bcond_with tcmalloc
 %bcond_with xio
+%bcond_with valgrind_devel
 %endif
 %bcond_without libs_compat
 %bcond_with lowmem_builder
@@ -133,7 +135,9 @@ BuildRequires:	python-virtualenv
 BuildRequires:	snappy-devel
 BuildRequires:	udev
 BuildRequires:	util-linux
+%if %{with valgrind_devel}
 BuildRequires:	valgrind-devel
+%endif
 BuildRequires:	xfsprogs
 BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -19,12 +19,12 @@
 %bcond_without ceph_test_package
 %endif
 %bcond_with make_check
-%bcond_with xio
-%ifnarch s390 s390x
+%ifnarch ppc64 ppc64le s390 s390x
 %bcond_without tcmalloc
+%bcond_without xio
 %else
-# no gperftools/tcmalloc on s390(x)
 %bcond_with tcmalloc
+%bcond_with xio
 %endif
 %bcond_without libs_compat
 %bcond_with lowmem_builder

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -82,7 +82,7 @@ Source99:       ceph-rpmlintrc
 %if 0%{?is_opensuse}
 ExclusiveArch:  x86_64 aarch64 ppc64 ppc64le
 %else
-ExclusiveArch:  x86_64 aarch64
+ExclusiveArch:  x86_64 aarch64 ppc64 ppc64le s390 s390x
 %endif
 %endif
 #################################################################################


### PR DESCRIPTION
For FATE#321098 etc. we need to ship the ceph client code for these architectures. That means we have to somehow build the entire ceph.spec