### PR TITLE
rpm: tell openSUSE to never clean the spec file

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1691,3 +1691,4 @@ exit 0
 
 
 %changelog
+# nospeccleaner


### PR DESCRIPTION
https://github.com/openSUSE/spec-cleaner/commit/e8c4df75d65931df11e9b3cf9b67ed756306364b
added the ability to disable the openSUSE spec-cleaner.

Since our downstream spec file is heavily based on the upstream version and we
want to minimize divergence, it makes sense to never let spec-cleaner have its
way with the file.

Signed-off-by: Nathan Cutler <ncutler@suse.com>