### PR TITLE
install-deps.sh: disable xio build unconditionally

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -78,7 +78,8 @@ centos|fedora|rhel)
 opensuse|suse|sles)
         echo "Using zypper to install dependencies"
         $SUDO zypper --gpg-auto-import-keys --non-interactive install lsb-release systemd-rpm-macros
-        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+        sed -e 's/@//g' \
+            -e 's/%bcond_without xio/%bcond_with xio/g' < ceph.spec.in > $DIR/ceph.spec
         $SUDO zypper --non-interactive install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;
 *)


### PR DESCRIPTION
This fixes a problem where libxio-devel is not available on SLES.

Signed-off-by: Nathan Cutler <ncutler@suse.com>