### PR TITLE
rpm: BuildRequires gperftools >= 2.4

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -112,7 +112,7 @@ BuildRequires:	fuse-devel
 BuildRequires:	gcc-c++
 BuildRequires:	gdbm
 %if 0%{with tcmalloc}
-BuildRequires:	gperftools-devel
+BuildRequires:	gperftools-devel >= 2.4
 %endif
 BuildRequires:  jq
 BuildRequires:	leveldb-devel > 1.2


### PR DESCRIPTION
Ensure we have a recent gperftools available.

Signed-off-by: Nathan Cutler <ncutler@suse.com>