### PR TITLE
build/ops: make package groups comply with openSUSE guidelines

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -72,7 +72,7 @@ Release:	@RPM_RELEASE@%{?dist}
 Summary:	User space components of the Ceph file system
 License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT
 %if 0%{?suse_version}
-Group:         System/Filesystems
+Group:		System/Filesystems
 %endif
 URL:		http://ceph.com/
 Source0:	%{name}-%{version}.tar.bz2
@@ -218,7 +218,9 @@ on commodity hardware and delivers object, block and file system storage.
 #################################################################################
 %package base
 Summary:       Ceph Base Package
-Group:         System Environment/Base
+%if 0%{?suse_version}
+Group:         System/Filesystems
+%endif
 Requires:      ceph-common = %{version}-%{release}
 Requires:      librbd1 = %{version}-%{release}
 Requires:      librados2 = %{version}-%{release}
@@ -248,7 +250,9 @@ Base is the package that includes all the files shared amongst ceph servers
 
 %package -n ceph-common
 Summary:	Ceph Common
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	librbd1 = %{version}-%{release}
 Requires:	librados2 = %{version}-%{release}
 Requires:	libcephfs2 = %{version}-%{release}
@@ -271,7 +275,9 @@ Comprised of files that are common to Ceph clients and servers.
 
 %package mds
 Summary:	Ceph Metadata Server Daemon
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{version}-%{release}
 %description mds
 ceph-mds is the metadata server daemon for the Ceph distributed file system.
@@ -280,7 +286,9 @@ namespace, coordinating access to the shared OSD cluster.
 
 %package mon
 Summary:	Ceph Monitor Daemon
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{version}-%{release}
 # For ceph-rest-api
 %if 0%{?fedora} || 0%{?rhel}
@@ -298,7 +306,9 @@ of cluster membership, configuration, and state.
 %package mgr
 Summary:        Ceph Manager Daemon
 License:        LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT
-Group:          System Environment/Base
+%if 0%{?suse_version}
+Group:          System/Filesystems
+%endif
 Requires:       ceph-base = %{version}-%{release}
 
 %description mgr
@@ -309,13 +319,17 @@ exposes all these to the python modules.
 
 %package fuse
 Summary:	Ceph fuse-based client
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 %description fuse
 FUSE based client for Ceph distributed network file system
 
 %package -n rbd-fuse
 Summary:	Ceph fuse-based client
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	librados2 = %{version}-%{release}
 Requires:	librbd1 = %{version}-%{release}
 %description -n rbd-fuse
@@ -323,7 +337,9 @@ FUSE based client to map Ceph rbd images to files
 
 %package -n rbd-mirror
 Summary:	Ceph daemon for mirroring RBD images
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-common = %{version}-%{release}
 Requires:	librados2 = %{version}-%{release}
 %description -n rbd-mirror
@@ -332,7 +348,9 @@ changes asynchronously.
 
 %package -n rbd-nbd
 Summary:	Ceph RBD client base on NBD
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	librados2 = %{version}-%{release}
 Requires:	librbd1 = %{version}-%{release}
 %description -n rbd-nbd
@@ -340,7 +358,9 @@ NBD based client to map Ceph rbd images to local device
 
 %package radosgw
 Summary:	Rados REST gateway
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-common = %{version}-%{release}
 %if 0%{with selinux}
 Requires:	ceph-selinux = %{version}-%{release}
@@ -359,7 +379,9 @@ service as well as the OpenStack Object Storage ("Swift") API.
 %if %{with ocf}
 %package resource-agents
 Summary:	OCF-compliant resource agents for Ceph daemons
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 License:	LGPL-2.0
 Requires:	ceph-base = %{version}
 Requires:	resource-agents
@@ -371,7 +393,9 @@ managers such as Pacemaker.
 
 %package osd
 Summary:	Ceph Object Storage Daemon
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{version}-%{release}
 # for sgdisk, used by ceph-disk
 %if 0%{?fedora} || 0%{?rhel}
@@ -388,7 +412,9 @@ and providing access to them over the network.
 
 %package -n librados2
 Summary:	RADOS distributed object store client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{version}-%{release}
@@ -401,7 +427,9 @@ store using a simple file-like interface.
 
 %package -n librados-devel
 Summary:	RADOS headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{version}-%{release}
 Obsoletes:	ceph-devel < %{version}-%{release}
@@ -413,7 +441,9 @@ that use RADOS object store.
 
 %package -n librgw2
 Summary:	RADOS gateway client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{version}-%{release}
 %description -n librgw2
@@ -422,7 +452,9 @@ This package provides a library implementation of the RADOS gateway
 
 %package -n librgw-devel
 Summary:	RADOS gateway client library
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librados-devel = %{version}-%{release}
 Requires:	librgw2 = %{version}-%{release}
@@ -434,7 +466,9 @@ that use RADOS gateway client library.
 
 %package -n python-rgw
 Summary:	Python 2 libraries for the RADOS gateway
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librgw2 = %{version}-%{release}
 Requires:	python-rados = %{version}-%{release}
@@ -445,7 +479,9 @@ gateway.
 
 %package -n python%{python3_pkgversion}-rgw
 Summary:	Python 3 libraries for the RADOS gateway
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librgw2 = %{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{version}-%{release}
@@ -455,7 +491,9 @@ gateway.
 
 %package -n python-rados
 Summary:	Python 2 libraries for the RADOS object store
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{version}-%{release}
 Obsoletes:	python-ceph < %{version}-%{release}
@@ -465,7 +503,9 @@ object store.
 
 %package -n python%{python3_pkgversion}-rados
 Summary:	Python 3 libraries for the RADOS object store
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	python%{python3_pkgversion}
 Requires:	librados2 = %{version}-%{release}
@@ -475,7 +515,9 @@ object store.
 
 %package -n libradosstriper1
 Summary:	RADOS striping interface
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{version}-%{release}
 %description -n libradosstriper1
@@ -485,7 +527,9 @@ an interface very similar to the rados one.
 
 %package -n libradosstriper-devel
 Summary:	RADOS striping interface headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	libradosstriper1 = %{version}-%{release}
 Requires:	librados-devel = %{version}-%{release}
@@ -498,7 +542,9 @@ that use RADOS striping interface.
 
 %package -n librbd1
 Summary:	RADOS block device client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora}
@@ -512,7 +558,9 @@ shared library allowing applications to manage these block devices.
 
 %package -n librbd-devel
 Summary:	RADOS block device headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librbd1 = %{version}-%{release}
 Requires:	librados-devel = %{version}-%{release}
@@ -525,7 +573,9 @@ that use RADOS block device.
 
 %package -n python-rbd
 Summary:	Python 2 libraries for the RADOS block device
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librbd1 = %{version}-%{release}
 Requires:	python-rados = %{version}-%{release}
@@ -536,7 +586,9 @@ block device.
 
 %package -n python%{python3_pkgversion}-rbd
 Summary:	Python 3 libraries for the RADOS block device
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librbd1 = %{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{version}-%{release}
@@ -546,7 +598,9 @@ block device.
 
 %package -n libcephfs2
 Summary:	Ceph distributed file system client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{version}-%{release}
@@ -560,7 +614,9 @@ POSIX-like interface.
 
 %package -n libcephfs-devel
 Summary:	Ceph distributed file system headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{version}-%{release}
 Requires:	librados-devel = %{version}-%{release}
@@ -573,7 +629,9 @@ that use Cephs distributed file system.
 
 %package -n python-cephfs
 Summary:	Python 2 libraries for Ceph distributed file system
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{version}-%{release}
 %if 0%{?suse_version}
@@ -586,7 +644,9 @@ file system.
 
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{version}-%{release}
@@ -596,7 +656,9 @@ file system.
 
 %package -n python%{python3_pkgversion}-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 %description -n python%{python3_pkgversion}-ceph-argparse
 This package contains types and routines for Python 3 used by the Ceph CLI as
@@ -607,7 +669,9 @@ descriptions, and submitting the command to the appropriate daemon.
 %if 0%{with ceph_test_package}
 %package -n ceph-test
 Summary:	Ceph benchmarks and test tools
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Benchmark
+%endif
 License:	LGPL-2.0
 Requires:	ceph-common
 Requires:	xmlstarlet
@@ -619,7 +683,9 @@ This package contains Ceph benchmarks and test tools.
 
 %package -n libcephfs_jni1
 Summary:	Java Native Interface library for CephFS Java bindings
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries/Java
+%endif
 License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs2 = %{version}-%{release}
@@ -629,7 +695,9 @@ bindings.
 
 %package -n libcephfs_jni-devel
 Summary:	Development files for CephFS Java Native Interface library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/Java
+%endif
 License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs_jni1 = %{version}-%{release}
@@ -642,7 +710,9 @@ library.
 
 %package -n cephfs-java
 Summary:	Java libraries for the Ceph File System
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries/Java
+%endif
 License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs_jni1 = %{version}-%{release}
@@ -657,7 +727,9 @@ This package contains the Java libraries for the Ceph File System.
 
 %package selinux
 Summary:	SELinux support for Ceph MON, OSD and MDS
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{version}-%{release}
 Requires:	policycoreutils, libselinux-utils
 Requires(post): selinux-policy-base >= %{_selinux_policy_version}, policycoreutils, gawk
@@ -671,7 +743,9 @@ populated file-systems.
 
 %package -n python-ceph-compat
 Summary:	Compatibility package for Cephs python libraries
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Obsoletes:	python-ceph
 Requires:	python-rados = %{version}-%{release}


### PR DESCRIPTION
. . . and put all Group: lines in SUSE conditional blocks.

Fixes: http://tracker.ceph.com/issues/19184
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit a3d6d4f75ed10ec62c2b56bdfa5290e8131d3198)

Conflicts:
	ceph.spec.in (no %{epoch} in downstream spec file)