### PR TITLE
build/ops: rpm: install python-six in build environment

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -130,6 +130,7 @@ BuildRequires:	python
 BuildRequires:	python-devel
 BuildRequires:	python-nose
 BuildRequires:	python-requests
+BuildRequires:	python-six
 BuildRequires:	python-sphinx
 BuildRequires:	python-virtualenv
 BuildRequires:	snappy-devel


### PR DESCRIPTION
Avoids FTBFS in openSUSE Tumbleweed with GCC7:

[ 1225s] Scanning dependencies of target cython3_cephfs
[ 1225s] Traceback (most recent call last):
[ 1225s]   File "/home/abuild/rpmbuild/BUILD/ceph-12.0.2+git.1493295295.8c88dc6/src/pybind/cephfs/setup.py", line 18, in <module>
[ 1225s]     from setuptools import setup
[ 1225s]   File "/usr/lib/python3.6/site-packages/setuptools/__init__.py", line 10, in <module>
[ 1225s]     from six.moves import filter, map
[ 1225s] ModuleNotFoundError: No module named 'six'
[ 1225s] make[2]: *** [src/pybind/cephfs3/CMakeFiles/cython3_cephfs.dir/build.make:57: src/pybind/cephfs3/CMakeFiles/cython3_cephfs] Error 1
[ 1225s] make[1]: *** [CMakeFiles/Makefile2:3653: src/pybind/cephfs3/CMakeFiles/cython3_cephfs.dir/all] Error 2
[ 1225s] make[1]: *** Waiting for unfinished jobs....

Fixes: http://tracker.ceph.com/issues/19869
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 83485e968a0630b1c62d82c3ea29ae60d49f073e)