### PR TITLE
ReplicatedPG: drop CACHE_PIN->WRITESAME req translation

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4462,16 +4462,6 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
     bufferlist::iterator bp = osd_op.indata.begin();
 
-    if ((op.op == CEPH_OSD_OP_CACHE_PIN) && (osd_op.indata.length())) {
-      // CEPH_OSD_OP_CACHE_PIN opcode was used in SES2[.1] for WRITESAME.
-      // Luckily this is easily detectable via the data buffer, which is only
-      // present in WRITESAME requests.
-      dout(10) << "munging CACHE_PIN -> WRITESAME. datalen:"
-	       << osd_op.indata.length() << " off:" << op.writesame.offset
-	       << " len:" << op.writesame.length << dendl;
-      op.op = CEPH_OSD_OP_WRITESAME;
-    }
-
     // user-visible modifcation?
     switch (op.op) {
       // non user-visible modifications
@@ -5669,6 +5659,14 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
     case CEPH_OSD_OP_CACHE_PIN:
       tracepoint(osd, do_osd_op_pre_cache_pin, soid.oid.name.c_str(), soid.snap.val);
+      if (osd_op.indata.length()) {
+	// CEPH_OSD_OP_CACHE_PIN opcode was used in SES2[.1] for WRITESAME.
+        derr << "malformed cache_pin request, potentially due to old client"
+	     << dendl;
+	result = -EINVAL;
+	break;
+      }
+
       if ((!pool.info.is_tier() ||
 	  pool.info.cache_mode == pg_pool_t::CACHEMODE_NONE)) {
         result = -EINVAL;


### PR DESCRIPTION
With SES2[.1], writesame used rados write opcode 36. With SES3 and later
write opcode 36 has been assigned to cache-pin. writesame instead uses
write opcode 38, which was accepted upstream. To handle the SES2[.1] ->
SES3 API mismatch, CACHE_PIN -> WRITESAME request transformation logic
was added (via 99468458f269029ca6c6cbe158059fa669d5dcaf).

With SES2.1 iSCSI gateways no longer supported, this logic can be
removed from the SES5 branch, reducing the upstream delta.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1038063

Signed-off-by: David Disseldorp <ddiss@suse.de>
Reviewed-by: Jan Fajerski <jfajerski@suse.com>