### PR TITLE
Revert "build/ops: rpm: install python-six in build environment"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -130,7 +130,6 @@ BuildRequires:	python
 BuildRequires:	python-devel
 BuildRequires:	python-nose
 BuildRequires:	python-requests
-BuildRequires:	python-six
 BuildRequires:	python-sphinx
 BuildRequires:	python-virtualenv
 BuildRequires:	snappy-devel


### PR DESCRIPTION
I can no longer reproduce the build failure that this was "fixing".