### PR TITLE
qa: changes to deepsea task to enable CephFS integration testing

### DIFF
--- a/qa/deepsea/2disks.yaml
+++ b/qa/deepsea/2disks.yaml
@@ -1,0 +1,4 @@
+openstack:
+- volumes: # attached to each instance
+    count: 2
+    size: 10 # GB

--- a/qa/deepsea/2nodes.yaml
+++ b/qa/deepsea/2nodes.yaml
@@ -1,0 +1,4 @@
+ceph_cm: salt
+roles:
+- [master.a]
+- [node.1]

--- a/qa/deepsea/3nodes.yaml
+++ b/qa/deepsea/3nodes.yaml
@@ -1,0 +1,5 @@
+ceph_cm: salt
+roles:
+- [master.a]
+- [node.1]
+- [node.2]

--- a/qa/deepsea/4nodes.yaml
+++ b/qa/deepsea/4nodes.yaml
@@ -1,0 +1,6 @@
+ceph_cm: salt
+roles:
+- [master.a]
+- [node.1]
+- [node.2]
+- [node.3]

--- a/qa/deepsea/health-mds.yaml
+++ b/qa/deepsea/health-mds.yaml
@@ -1,0 +1,10 @@
+tasks:
+- install:
+- deepsea:
+    repo: https://github.com/smithfarm/DeepSea.git
+    branch: wip-qa-suite
+    exec:
+    - suites/basic/health-mds.sh
+#- exec:
+#    master.a:
+#      - sleep 1000000000 # forever

--- a/qa/deepsea/health-ok.yaml
+++ b/qa/deepsea/health-ok.yaml
@@ -1,0 +1,8 @@
+tasks:
+- install:
+- deepsea:
+    repo: https://github.com/smithfarm/DeepSea.git
+    branch: wip-qa-suite
+#- exec:
+#    master.a:
+#      - sleep 1000000000 # forever

--- a/qa/suites/deepsea-test.yaml
+++ b/qa/suites/deepsea-test.yaml
@@ -5,12 +5,12 @@ roles:
 openstack:
 - volumes: # attached to each instance
     count: 2
-    size: 30 # GB
+    size: 10 # GB
 tasks:
 - install:
 - deepsea:
     repo: https://github.com/smithfarm/DeepSea.git
-    branch: wip-teuthology-suite
+    branch: wip-qa-suite
 #- exec:
 #    master.a:
 #      - sleep 1000000000 # forever

--- a/qa/suites/deepsea/basic/2nodes/health-mds/2disks.yaml
+++ b/qa/suites/deepsea/basic/2nodes/health-mds/2disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2disks.yaml

--- a/qa/suites/deepsea/basic/2nodes/health-mds/2nodes.yaml
+++ b/qa/suites/deepsea/basic/2nodes/health-mds/2nodes.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2nodes.yaml

--- a/qa/suites/deepsea/basic/2nodes/health-mds/health-mds.yaml
+++ b/qa/suites/deepsea/basic/2nodes/health-mds/health-mds.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/health-mds.yaml

--- a/qa/suites/deepsea/basic/2nodes/health-ok/2disks.yaml
+++ b/qa/suites/deepsea/basic/2nodes/health-ok/2disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2disks.yaml

--- a/qa/suites/deepsea/basic/2nodes/health-ok/2nodes.yaml
+++ b/qa/suites/deepsea/basic/2nodes/health-ok/2nodes.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2nodes.yaml

--- a/qa/suites/deepsea/basic/2nodes/health-ok/health-ok.yaml
+++ b/qa/suites/deepsea/basic/2nodes/health-ok/health-ok.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/health-ok.yaml

--- a/qa/suites/deepsea/basic/3nodes/health-mds/2disks.yaml
+++ b/qa/suites/deepsea/basic/3nodes/health-mds/2disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2disks.yaml

--- a/qa/suites/deepsea/basic/3nodes/health-mds/3nodes.yaml
+++ b/qa/suites/deepsea/basic/3nodes/health-mds/3nodes.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/3nodes.yaml

--- a/qa/suites/deepsea/basic/3nodes/health-mds/health-mds.yaml
+++ b/qa/suites/deepsea/basic/3nodes/health-mds/health-mds.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/health-mds.yaml

--- a/qa/suites/deepsea/basic/3nodes/health-ok/2disks.yaml
+++ b/qa/suites/deepsea/basic/3nodes/health-ok/2disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2disks.yaml

--- a/qa/suites/deepsea/basic/3nodes/health-ok/3nodes.yaml
+++ b/qa/suites/deepsea/basic/3nodes/health-ok/3nodes.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/3nodes.yaml

--- a/qa/suites/deepsea/basic/3nodes/health-ok/health-ok.yaml
+++ b/qa/suites/deepsea/basic/3nodes/health-ok/health-ok.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/health-ok.yaml

--- a/qa/suites/deepsea/basic/4nodes/health-ok/2disks.yaml
+++ b/qa/suites/deepsea/basic/4nodes/health-ok/2disks.yaml
@@ -1,1 +1,0 @@
-../../../../../deepsea/2disks.yaml

--- a/qa/suites/deepsea/basic/4nodes/health-ok/2disks.yaml
+++ b/qa/suites/deepsea/basic/4nodes/health-ok/2disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/2disks.yaml

--- a/qa/suites/deepsea/basic/4nodes/health-ok/4nodes.yaml
+++ b/qa/suites/deepsea/basic/4nodes/health-ok/4nodes.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/4nodes.yaml

--- a/qa/suites/deepsea/basic/4nodes/health-ok/4nodes.yaml
+++ b/qa/suites/deepsea/basic/4nodes/health-ok/4nodes.yaml
@@ -1,1 +1,0 @@
-../../../../../deepsea/4nodes.yaml

--- a/qa/suites/deepsea/basic/4nodes/health-ok/health-ok.yaml
+++ b/qa/suites/deepsea/basic/4nodes/health-ok/health-ok.yaml
@@ -1,1 +1,0 @@
-../../../../../deepsea/health-ok.yaml

--- a/qa/suites/deepsea/basic/4nodes/health-ok/health-ok.yaml
+++ b/qa/suites/deepsea/basic/4nodes/health-ok/health-ok.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/health-ok.yaml

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -103,6 +103,21 @@ class DeepSea(Task):
             'install',
             ])
 
+        self.log.info("printing branch name and sha1...")
+        self.salt.master_remote.run(args=[
+            'cd',
+            'DeepSea',
+            run.Raw(';'),
+            'git',
+            'rev-parse',
+            '--abbrev-ref',
+            'HEAD',
+            run.Raw(';'),
+            'git',
+            'rev-parse',
+            'HEAD',
+            ])
+
         self.log.info("installing deepsea dependencies...")
         self.salt.master_remote.run(args = [
             'sudo',

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -45,7 +45,7 @@ class DeepSea(Task):
         tasks
         - deepsea:
             exec:
-            - workunits/basic-health-ok.sh
+            - suites/basic/health-ok.sh
     """
     def __init__(self, ctx, config):
         super(DeepSea, self).__init__(ctx, config)
@@ -57,7 +57,7 @@ class DeepSea(Task):
             'deepsea task only accepts a dict for configuration'
         self.config["repo"] = config.get('repo', 'https://github.com/SUSE/DeepSea.git')
         self.config["branch"] = config.get('branch', 'master')
-        self.config["exec"] = config.get('exec', ['workunits/basic-health-ok.sh'])
+        self.config["exec"] = config.get('exec', ['suites/basic/health-ok.sh'])
         assert isinstance(self.config["exec"], list), \
             'exec property of deepsea yaml must be a list'
 

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -91,19 +91,14 @@ class DeepSea(Task):
         self.salt.master_remote.run(args=[
             'git',
             'clone',
+            '--depth',
+            '1',
             '--branch',
             self.config["branch"],
             self.config["repo"],
-            run.Raw(';'),
-            'cd',
-            'DeepSea',
-            run.Raw(';'),
-            'sudo',
-            'make',
-            'install',
             ])
 
-        self.log.info("printing branch name and sha1...")
+        self.log.info("printing DeepSea branch name and sha1...")
         self.salt.master_remote.run(args=[
             'cd',
             'DeepSea',
@@ -116,6 +111,16 @@ class DeepSea(Task):
             'git',
             'rev-parse',
             'HEAD',
+            ])
+
+        self.log.info("Running \"make install\" in DeepSea clone...")
+        self.salt.master_remote.run(args=[
+            'cd',
+            'DeepSea',
+            run.Raw(';'),
+            'sudo',
+            'make',
+            'install',
             ])
 
         self.log.info("installing deepsea dependencies...")


### PR DESCRIPTION
Also breaks up the test yaml into reusable chunks (stored in `qa/deepsea/`) and implements a "DeepSea integration test suite" under `qa/suites/deepsea/` to enable teuthology to automate the tests.

N.B.: This is the companion PR to https://github.com/SUSE/DeepSea/pull/322