### PR TITLE
qa: create rbd pool before running rbd test

### DIFF
--- a/qa/suites/deepsea/ceph-test/rbd-cli-generic/tasks/1-rbd-cli-generic.yaml
+++ b/qa/suites/deepsea/ceph-test/rbd-cli-generic/tasks/1-rbd-cli-generic.yaml
@@ -7,6 +7,7 @@ tasks:
 - exec:
     client.0:
       - "chmod a+r /etc/ceph/ceph.client.admin.keyring"
+      - "ceph osd pool create rbd 8"
 # the "workunit" task runs commands as the user "ubuntu"
 - workunit:
     clients:


### PR DESCRIPTION
This is a stopgap measure - I still haven't figured out why this test script [*] isn't failing upstream.

[*] https://github.com/ceph/ceph/blob/master/qa/workunits/rbd/cli_generic.sh