### PR TITLE
ceph.spec.in: obsolete libxio

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -261,6 +261,7 @@ Requires:      psmisc
 Requires:      which
 %if 0%{?suse_version}
 Recommends:    ntp-daemon
+Obsoletes:     libxio
 %endif
 %description base
 Base is the package that includes all the files shared amongst ceph servers
@@ -282,6 +283,7 @@ Requires:	python-prettytable
 %endif
 %if 0%{?suse_version}
 Requires:	python-PrettyTable
+Obsoletes:      libxio
 %endif
 Requires:	python-requests
 %{?systemd_requires}


### PR DESCRIPTION
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1047020

and paves the way to dropping libxio