### PR TITLE
osd: move CMPEXT response munging into completion function

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1332,8 +1332,8 @@ protected:
 
   friend class C_ChecksumRead;
 
-  int do_extent_cmp(OpContext *ctx, OSDOp& osd_op);
-  int finish_extent_cmp(OSDOp& osd_op, const bufferlist &read_bl);
+  int do_extent_cmp(OpContext *ctx, OSDOp& osd_op, bool munged);
+  int finish_extent_cmp(OSDOp& osd_op, const bufferlist &read_bl, bool munged);
 
   friend class C_ExtentCmpRead;
 


### PR DESCRIPTION
6f860ff8da36bd74954b5982ce4cc1741b34bcfe added functionality to munge
old (SES <= 4) cmpext requests and responses, to ensure that clients
weren't affected by the API change.
cmpext on EC support (04cf38cc159479417562da36848537ee99892d7d), added
a cmpext asynchronous completion handler which broke response munging.

This change reinstates cmpext response munging, ensuring that the munged
request state is tracked through to the completion handler.
(bsc#1047244).

Signed-off-by: David Disseldorp <ddiss@suse.de>