### PR TITLE
ceph_release: luminous is now 'stable' (12.2.x)

### DIFF
--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
 12
 luminous
-rc
+stable


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 8f0945a0f39e7da629fa94f406bc1314e1b39fc8)