### PR TITLE
build/ops: python-numpy-devel build dependency for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -117,6 +117,7 @@ BuildRequires:	python-werkzeug
 %if 0%{?suse_version}
 BuildRequires:	python-CherryPy
 BuildRequires:	python-Werkzeug
+BuildRequires:	python-numpy-devel
 %endif
 BuildRequires:	python-pecan
 BuildRequires:	socat


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21176