### PR TITLE
tests: deepsea: use 3-node cluster for openATTIC deployment

### DIFF
--- a/qa/suites/deepsea/basic/openattic/cluster/2nodes2disks.yaml
+++ b/qa/suites/deepsea/basic/openattic/cluster/2nodes2disks.yaml
@@ -1,1 +1,0 @@
-../../../../../deepsea/2nodes2disks.yaml

--- a/qa/suites/deepsea/basic/openattic/cluster/3nodes2disks.yaml
+++ b/qa/suites/deepsea/basic/openattic/cluster/3nodes2disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/3nodes2disks.yaml


### PR DESCRIPTION
Companion PR to https://github.com/SUSE/DeepSea/pull/643 (merge it first, then this one)