### PR TITLE
ceph-disk: fix mountpoint check for systemctl enable --runtime

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3248,7 +3248,7 @@ def systemd_start(
     osd_id,
 ):
     systemd_disable(path, osd_id)
-    if is_mounted(path):
+    if os.path.ismount(path):
         style = ['--runtime']
     else:
         style = []


### PR DESCRIPTION
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1051598
Signed-off-by: Chao Xiong <cxiong@suse.com>
Acked-by: Nathan Cutler <ncutler@suse.com>