### PR TITLE
systemd: restore TasksMax=infinity

### DIFF
--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -11,6 +11,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
+TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -17,6 +17,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
+TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=5

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -12,6 +12,7 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
+TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=30

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -10,6 +10,7 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
+TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30s
 StartLimitBurst=5

--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -17,6 +17,7 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-rbd-mirror.target


### PR DESCRIPTION
To prevent bugs like https://bugzilla.suse.com/show_bug.cgi?id=1061461

IIRC the original revert was done because the systemd in SLES did not understand the TasksMax parameter. But I tried it with the systemd that is in SLE-12-SP3 and it worked fine.