### PR TITLE
rgw: stop/join TokenCache revoke thread only if started.

### DIFF
--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -277,8 +277,11 @@ class TokenCache {
   ~TokenCache() {
     down_flag = true;
 
-    revocator.stop();
-    revocator.join();
+    // Only stop and join if revocator thread is started.
+    if (revocator.is_started()) {
+      revocator.stop();
+      revocator.join();
+    }
   }
 
 public:


### PR DESCRIPTION
Thread::join triggers an assert otherwise.

Fixes http://tracker.ceph.com/issues/21666

Signed-off-by: Karol Mroz <kmroz@suse.de>
(cherry picked from commit 26f2da083c7dd21b89c1c1e6c498b14e034364a6)