### PR TITLE
rgw: set sync_from_all as true when no value is seen

### DIFF
--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -122,7 +122,7 @@ public:
   static bool decode_json(const char *name, C& container, void (*cb)(C&, JSONObj *obj), JSONObj *obj, bool mandatory = false);
 
   template<class T>
-  static void decode_json(const char *name, T& val, T& default_val, JSONObj *obj);
+  static void decode_json(const char *name, T& val, const T& default_val, JSONObj *obj);
 };
 
 template<class T>
@@ -304,7 +304,7 @@ bool JSONDecoder::decode_json(const char *name, C& container, void (*cb)(C&, JSO
 }
 
 template<class T>
-void JSONDecoder::decode_json(const char *name, T& val, T& default_val, JSONObj *obj)
+void JSONDecoder::decode_json(const char *name, T& val, const T& default_val, JSONObj *obj)
 {
   JSONObjIter iter = obj->find_first(name);
   if (iter.end()) {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -986,7 +986,7 @@ void RGWZone::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("bucket_index_max_shards", bucket_index_max_shards, obj);
   JSONDecoder::decode_json("read_only", read_only, obj);
   JSONDecoder::decode_json("tier_type", tier_type, obj);
-  JSONDecoder::decode_json("sync_from_all", sync_from_all, obj);
+  JSONDecoder::decode_json("sync_from_all", sync_from_all, true, obj);
   JSONDecoder::decode_json("sync_from", sync_from, obj);
 }
 


### PR DESCRIPTION
In order to support jewel-luminous multisite scenarios where when a
jewel cluster is the master, the sync-from-all json field wouldn't be
set leading to the secondary not syncing data as this value can't be
overriden to true, so defaulting the value of sync_from_all to true when
we don't encounter it in the json

Fixes: http://tracker.ceph.com/issues/22062 (tagged for backports as well)
bsc#1067705
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>
(cherry picked from commit e0116fa42020ff5c0d78101b9b3b15e62236b4b8)