### PR TITLE
rgw: keystone: bump up logging when error is received

### DIFF
--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -101,8 +101,6 @@ TokenEngine::get_from_keystone(const std::string& token) const
 
   /* NULL terminate for debug output. */
   token_body_bl.append(static_cast<char>(0));
-  ldout(cct, 20) << "received response status=" << validate.get_http_status()
-                 << ", body=" << token_body_bl.c_str() << dendl;
 
   /* Detect Keystone rejection earlier than during the token parsing.
    * Although failure at the parsing phase doesn't impose a threat,
@@ -114,8 +112,13 @@ TokenEngine::get_from_keystone(const std::string& token) const
       validate.get_http_status() ==
           /* Most likely: non-existent token supplied by the client. */
           RGWValidateKeystoneToken::HTTP_STATUS_NOTFOUND) {
+    ldout(cct, 5) << "Failed keystone auth from " << url << " with "
+                  << validate.get_http_status() << dendl;
     return boost::none;
   }
+
+  ldout(cct, 20) << "received response status=" << validate.get_http_status()
+                 << ", body=" << token_body_bl.c_str() << dendl;
 
   TokenEngine::token_envelope_t token_body;
   ret = token_body.parse(cct, token, token_body_bl, config.get_api_version());


### PR DESCRIPTION
When keystone engine is used and there is an error (often due to
misconfigured urls etc) these do not show up at the final logs as we
just return  -1 at the final stage. Adding logs at level 5 for these
cases, as they can help identify a possible misconfigured url or admin
token. Eg:

```
5 Failed keystone auth from http://localhost:5000/v3/v3/auth/tokens with 404
```

Fixes: http://tracker.ceph.com/issues/22151
bsc#1060904
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>
(cherry picked from commit 347c5148a57de9007d6c1293add6bf27004fce41)