### PR TITLE
build/ops: rpm: do not use macros in comment

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -74,7 +74,8 @@ Release:	@RPM_RELEASE@%{?dist}
 Epoch:		2
 %endif
 
-# define %_epoch_prefix macro which will expand to the empty string if %epoch is undefined
+# define _epoch_prefix macro which will expand to the empty string if epoch is
+# undefined
 %global _epoch_prefix %{?epoch:%{epoch}:}
 
 Summary:	User space components of the Ceph file system


### PR DESCRIPTION
Fixes RPMLINT error:

ceph.src:77: W: macro-in-comment %_epoch_prefix
ceph.src:77: W: macro-in-comment %epoch
There is a unescaped macro after a shell style comment in the specfile. Macros
are expanded everywhere, so check if it can cause a problem in this case and
escape the macro with another leading % if appropriate.

Signed-off-by: Nathan Cutler <ncutler@suse.com>