### PR TITLE
[RFC] build/ops: rpm: BuildRequire gcc-c++ >= 7

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -126,7 +126,7 @@ BuildRequires:	gperf
 BuildRequires:  cmake
 BuildRequires:	cryptsetup
 BuildRequires:	fuse-devel
-BuildRequires:	gcc-c++
+BuildRequires:	gcc-c++ >= 7
 BuildRequires:	gdbm
 %if 0%{with tcmalloc}
 BuildRequires:	gperftools-devel >= 2.4


### PR DESCRIPTION
Downstream-only for now. This will cause the build to fail on anything earlier
than Code 15 (i.e. openSUSE 15 and/or SLE 15)

Note: upstream is considering a proposal to make GCC-7 mandatory for master/Mimic, but it hasn't been approved/implemented yet.