### PR TITLE
tests: deepsea: increase number of OSDs in openattic test case

### DIFF
--- a/qa/deepsea/3nodes3disks.yaml
+++ b/qa/deepsea/3nodes3disks.yaml
@@ -1,0 +1,9 @@
+ceph_cm: salt
+roles:
+- [master.a]
+- [node.0]
+- [client.0]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB

--- a/qa/suites/deepsea/basic/openattic/cluster/3nodes2disks.yaml
+++ b/qa/suites/deepsea/basic/openattic/cluster/3nodes2disks.yaml
@@ -1,1 +1,0 @@
-../../../../../deepsea/3nodes2disks.yaml

--- a/qa/suites/deepsea/basic/openattic/cluster/3nodes3disks.yaml
+++ b/qa/suites/deepsea/basic/openattic/cluster/3nodes3disks.yaml
@@ -1,0 +1,1 @@
+../../../../../deepsea/3nodes3disks.yaml


### PR DESCRIPTION
With only 6 OSDs, Stage 4 fails when trying to create the cephfs_metadata pool:

cephfs metadata: Command "ceph osd pool create cephfs_metadata 128" run
    stdout:
    stderr: Error ERANGE:  pg_num 128 size 3 would mean 1248 total pgs, which exceeds max 1200 (mon_max_pg_per_osd 200 * num_in_osds 6)

This commit works around the problem by deploying 9 OSDs instead of 6. A more
involved, but superior fix will be to pre-create the pools before running Stage
4, ensuring that the number of PGs is commensurate wrt the number of OSDs in
the cluster. These two fixes are orthogonal, so proceeding with the quick one
first.

Signed-off-by: Nathan Cutler <ncutler@suse.com>