### PR TITLE
tests: deepsea: obtain dependencies from deepsea.spec.in

### DIFF
--- a/qa/deepsea/tasks.yaml
+++ b/qa/deepsea/tasks.yaml
@@ -2,5 +2,5 @@ tasks:
 - install:
 - deepsea:
     repo: https://github.com/SUSE/DeepSea.git
-    branch: master
+    branch: SES5
     exec: []

--- a/qa/suites/deepsea/ceph-test/pynfs/fsal/cephfs.yaml
+++ b/qa/suites/deepsea/ceph-test/pynfs/fsal/cephfs.yaml
@@ -1,4 +1,4 @@
 overrides:
   deepsea:
     exec:
-    - "suites/ceph-test/pynfs.sh --fsal=cephfs"
+    - "suites/ceph-test/pynfs.sh --cli --fsal=cephfs"

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -149,7 +149,7 @@ class DeepSea(Task):
             '--non-interactive',
             'install',
             '--no-recommends',
-            run.Raw('$(rpmspec --requires -q -v DeepSea/deepsea.spec | grep manual | awk \'{print $2}\')')
+            run.Raw('$(rpmspec --requires -q -v DeepSea/deepsea.spec.in | grep manual | awk \'{print $2}\')')
             ])
 
         self.log.info("listing minion keys...")


### PR DESCRIPTION
The deepsea spec file was templated recently. This was causing teuthology jobs
to fail when DeepSea was installed from source.

Signed-off-by: Nathan Cutler <ncutler@suse.com>