### PR TITLE
qa: test dashboard with Python 3

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -2,7 +2,7 @@ set(MGR_DASHBOARD_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-dashboard-virtualenv)
 
 add_custom_target(mgr-dashboard-test-venv
   COMMAND
-  ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python2.7 ${MGR_DASHBOARD_VIRTUALENV} &&
+  ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python3 ${MGR_DASHBOARD_VIRTUALENV} &&
   ${MGR_DASHBOARD_VIRTUALENV}/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/wheelhouse -r requirements.txt
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard
   COMMENT "dashboard tests virtualenv is being created")
@@ -14,7 +14,7 @@ set(mgr-dashboard-nodeenv ${CMAKE_CURRENT_BINARY_DIR}/node-env)
 
 add_custom_command(
   OUTPUT "${mgr-dashboard-nodeenv}/bin/npm"
-  COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python2.7 ${mgr-dashboard-nodeenv}
+  COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python3 ${mgr-dashboard-nodeenv}
   COMMAND ${mgr-dashboard-nodeenv}/bin/pip install nodeenv
   COMMAND ${mgr-dashboard-nodeenv}/bin/nodeenv -p -n 8.10.0
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
The dashboard will run on Python 3 downstream, so test it on that version.

Signed-off-by: Nathan Cutler <ncutler@suse.com>