### PR TITLE
ceph-ver-hack.sh: do not touch src/ceph_ver.h.in.cmake

### DIFF
--- a/etc/ceph_ver_hack.sh
+++ b/etc/ceph_ver_hack.sh
@@ -44,5 +44,3 @@
 #
 
 (git rev-parse HEAD ; git describe --match 'v*') 2> /dev/null > src/.git_version
-sed -i "s/@CEPH_GIT_VER@/$(head -n1 src/.git_version)/" src/ceph_ver.h.in.cmake
-sed -i "s/@CEPH_GIT_NICE_VER@/$(tail -n1 src/.git_version)/" src/ceph_ver.h.in.cmake


### PR DESCRIPTION
In luminous, cmake takes care of populating src/ceph_ver.h.in.cmake. For our tar_scm OBS source service-based tarball generation, the only file we need to populate is src/.git_version.

See the cmake code at https://github.com/SUSE/ceph/blob/ses5/src/CMakeLists.txt#L212-L219