### PR TITLE
let extract_parted_partition_numbers return a list

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1494,7 +1494,7 @@ def unmount(
 
 def extract_parted_partition_numbers(partitions):
     numbers_as_strings = re.findall('^\d+', partitions, re.MULTILINE)
-    return map(int, numbers_as_strings)
+    return list(map(int, numbers_as_strings))
 
 
 def get_free_partition_index(dev):


### PR DESCRIPTION
Python2 to Python3 changed the return of map() from a list to a
"map object" which is an interator. This commit turns the returned
"map object" back into a list.

Signed-off-by: Alexander Graul <agraul@suse.com>

Fixes https://github.com/SUSE/DeepSea/issues/1247