### PR TITLE
luminous: mgr/MgrClient: Protect daemon_health_metrics

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -465,5 +465,6 @@ int MgrClient::service_daemon_update_status(
 
 void MgrClient::update_osd_health(std::vector<OSDHealthMetric>&& metrics)
 {
+  Mutex::Locker l(lock);
   osd_health_metrics = std::move(metrics);
 }


### PR DESCRIPTION
Without holding the lock update_daemon_health() can race with
send_report() corrupting the daemon_health_metrics vector.

Fixes: http://tracker.ceph.com/issues/23352

Signed-off-by: Kjetil Joergensen <kjetil@medallia.com>
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>
(cherry picked from commit 4996506a6b4ab309110039ea29a075f14d09a379)

Conflicts:
	src/mgr/MgrClient.cc Function name is different in luminous