### PR TITLE
rgw: s3: awsv4 drop special handling for x-amz-credential

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -533,15 +533,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
       /* Preserving the original behaviour of get_v4_canonical_qs() here. */
       continue;
     }
-
-    if (key == "X-Amz-Credential") {
-      /* FIXME(rzarzynski): I can't find any comment in the previously linked
-       * Amazon's docs saying that X-Amz-Credential should be handled in this
-       * way. */
-      canonical_qs_map[key.to_string()] = val.to_string();
-    } else {
-      canonical_qs_map[aws4_uri_recode(key)] = aws4_uri_recode(val);
-    }
+    canonical_qs_map[aws4_uri_recode(key)] = aws4_uri_recode(val);
   }
 
   /* Thanks to the early exist we have the guarantee that canonical_qs_map has


### PR DESCRIPTION
While s3 docs mention that every byte must be urlencoded, they are relaxed in
its implementation, when testing this behaviour on aws s3 itself, they seem to
be relaxed in handling aws credentials of the form

X-Amz-Credential=access1/20180817T123456Z/us-east-1...

wherein

X-Amz-Credential=access1%2F2018...

is expected. This allows for clients requesting the urls in both forms to
succeed as aws s3 does at the moment

bsc#1105251
Fixes: http://tracker.ceph.com/issues/26965 (needs backport)
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>