### PR TITLE
ceph-disk: compatibility fix for python 3

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -915,7 +915,7 @@ def is_mounted(dev):
             path = fields[1]
             if os.path.isabs(mounts_dev) and os.path.exists(mounts_dev):
                 mounts_dev = os.path.realpath(mounts_dev)
-                if mounts_dev == dev:
+                if _bytes2str(mounts_dev) == dev:
                     return _bytes2str(path)
     return None
 


### PR DESCRIPTION
In python 3, dev is a string, but mounts_dev is bytes, so they can't
compare equal, resulting in is_mounted() returning None for mounted
OSDs.

Signed-off-by: Tim Serong <tserong@suse.com>