### PR TITLE
qa: split off Salt task from DeepSea task

### DIFF
--- a/qa/deepsea/deepsea.yaml
+++ b/qa/deepsea/deepsea.yaml
@@ -1,4 +1,6 @@
 tasks:
+- clock:
 - install:
     install_ceph_packages: false
+- salt:
 - deepsea:

--- a/qa/deepsea/deepsea.yaml
+++ b/qa/deepsea/deepsea.yaml
@@ -2,5 +2,6 @@ tasks:
 - clock:
 - install:
     install_ceph_packages: false
+    extra_system_packages: ['salt-master', 'salt-minion', 'salt-api']
 - salt:
 - deepsea:

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -1,52 +1,28 @@
 '''
-Task to deploy clusters with DeepSea
+Task that deploys a Ceph cluster using DeepSea
 '''
 import logging
 import os.path
 import time
 
+from salt_manager import SaltManager
 from teuthology import misc
-from teuthology.exceptions import (CommandCrashedError, CommandFailedError,
-                                   ConnectionLostError)
-from teuthology.exceptions import ConfigError
+from teuthology.exceptions import (CommandFailedError, ConfigError)
 from teuthology.orchestra import run
-from teuthology.salt import Salt
 from teuthology.task import Task
-from teuthology.job_status import get_status
-from util import get_remote_for_role
 
 log = logging.getLogger(__name__)
 
 class DeepSea(Task):
     """
-    Automated DeepSea integration testing via teuthology: set up a Salt
-    cluster, clone the DeepSea git repo, run DeepSea integration test(s) 
+    Install DeepSea on the Salt Master node.
 
-    The number of machines in the cluster is determined by the roles stanza, as
-    usual. One, and only one, of the machines must have a role of type
-    "master", e.g.  master.1 or master.a (the part following the dot is not
-    significant, but must be there).
+    Assumes a Salt cluster is already running (use the Salt task to achieve this).
 
-    The task starts the Salt Master daemon on the master node, and Salt Minion
-    daemons on all the nodes (including the master node), and ensures that the
-    minions are properly linked to the master. TODO: The role types are stored
-    in the role grain on the minions.
-
-    After that, the DeepSea git repo is cloned to the master node in
-    accordance with the "repo" and "branch" options (see below).
-
-    Finally, the task iterates over the list of commands given in the "exec"
-    property, executing each one inside the 'qa/' directory of the DeepSea repo
-    clone.
-
-    This task takes three mandatory options:
+    This task understands the following config keys:
 
         repo: (DeepSea git repo, e.g. https://github.com/SUSE/DeepSea.git)
         branch: (DeepSea git branch, e.g. master)
-        exec: (list of commands, relative to qa/ of the DeepSea repo)
-
-    Optional arguments:
-
         install:
             package|pkg deepsea will be installed via package system
             source|src  deepsea will be installed via 'make install' (default)
@@ -57,8 +33,6 @@ class DeepSea(Task):
         - deepsea:
             repo: https://github.com/SUSE/DeepSea.git
             branch: wip-foo
-            exec:
-            - suites/basic/health-ok.sh
             install: source
 
     :param ctx: the argparse.Namespace object
@@ -66,11 +40,6 @@ class DeepSea(Task):
     """
     def __init__(self, ctx, config):
         super(DeepSea, self).__init__(ctx, config)
-        log.debug("__init__: self.config is ->{}<-".format(self.config))
-        if self.config is None:
-            self.config = {}
-        assert isinstance(self.config, dict), \
-            'deepsea task only accepts a dict for configuration'
 
         def _check_config_key(key, default_value):
             if key not in self.config or not self.config[key]:
@@ -82,20 +51,35 @@ class DeepSea(Task):
 
         log.debug("Munged config is {}".format(self.config))
 
-        # set remote name for salt to pick it up. Setting the remote itself will
-        # crash the reporting tool since it doesn't know how to turn the object
-        # into a string
-        master_role = 'client.salt_master'
-        self.config["master_remote"] = get_remote_for_role(self.ctx,
-                master_role).name
-        self.log.info("master remote: {}".format(self.config["master_remote"]))
-        self.salt = Salt(self.ctx, self.config)
+        self.sm = SaltManager(self.ctx, self.config)
+        self.master_remote = self.sm.master_remote
 
-    def make_install(self):
-        self.log.info("DeepSea repo: {}".format(self.config["repo"]))
-        self.log.info("DeepSea branch: {}".format(self.config["branch"]))
+    def __purge_osds(self):
+        # FIXME: purge osds only on nodes that have osd role
+        for _remote in self.ctx.cluster.remotes.iterkeys():
+            self.log.info("stopping OSD services on {}"
+                .format(_remote.hostname))
+            _remote.run(args=[
+                'sudo', 'sh', '-c',
+                'systemctl stop ceph-osd.target ; sleep 10'
+                ])
+            self.log.info("unmounting OSD partitions on {}"
+                .format(_remote.hostname))
+            # bluestore XFS partition is vd?1 - unmount up to five OSDs
+            _remote.run(args=[
+                'sudo', 'sh', '-c',
+                'for f in vdb1 vdc1 vdd1 vde1 vdf1 ; do test -b /dev/$f && umount /dev/$f || true ; done'
+                ])
+            # filestore XFS partition is vd?2 - unmount up to five OSDs
+            _remote.run(args=[
+                'sudo', 'sh', '-c',
+                'for f in vdb2 vdc2 vdd2 vde2 vdf2; do test -b /dev/$f && umount /dev/$f || true ; done'
+                ])
 
-        self.salt.master_remote.run(args=[
+    def __install_deepsea_from_source(self):
+        self.log.info("Installing DeepSea from source - repo: {}, branch: {}"
+                      .format(self.config["repo"], self.config["branch"]))
+        self.master_remote.run(args=[
             'git',
             '--version',
             run.Raw(';'),
@@ -124,7 +108,7 @@ class DeepSea(Task):
             ])
 
         self.log.info("Running \"make install\" in DeepSea clone...")
-        self.salt.master_remote.run(args=[
+        self.master_remote.run(args=[
             'cd',
             'DeepSea',
             run.Raw(';'),
@@ -134,7 +118,7 @@ class DeepSea(Task):
             ])
 
         self.log.info("installing deepsea dependencies...")
-        self.salt.master_remote.run(args = [
+        self.master_remote.run(args = [
             'sudo',
             'zypper',
             '--non-interactive',
@@ -142,45 +126,40 @@ class DeepSea(Task):
             '--no-recommends',
             run.Raw('$(rpmspec --requires -q DeepSea/deepsea.spec.in 2>/dev/null)')
             ])
-        self.setup_salt()
 
-    def setup_salt(self):
-        self.log.info("listing minion keys...")
-        self.salt.master_remote.run(args = ['sudo', 'salt-key', '-L'])
-
-        self.log.info("iterating over all the test nodes...")
-        for _remote in self.ctx.cluster.remotes.iterkeys():
-            self.log.info("minion configuration for {}".format(_remote.hostname))
-            _remote.run(args = ['sudo', 'systemctl', 'status',
-                'salt-minion.service'])
-            _remote.run(args = ['sudo', 'cat', '/etc/salt/minion_id'])
-            _remote.run(args = ['sudo', 'cat', '/etc/salt/minion.d/master.conf'])
-
-        self.salt.ping_minions()
-
-    def setup(self):
-        super(DeepSea, self).setup()
-        if self.config['install'] in ['source', 'src']:
-            self.make_install()
-        elif self.config['install'] in ['package', 'pkg']:
-            self.salt.master_remote.run(args=[
+    def __install_deepsea_using_zypper(self):
+            self.log.info("Installing DeepSea using zypper")
+            self.master_remote.run(args=[
                 'sudo',
                 'zypper',
                 '--non-interactive',
+                'search',
+                '--details',
+                'deepsea'
+                ])
+            self.master_remote.run(args=[
+                'sudo',
+                'zypper',
+                '--non-interactive',
+                '--no-gpg-checks',
                 'install',
+                '--force',
+                '--no-recommends',
                 'deepsea',
                 'deepsea-cli',
                 'deepsea-qa'
                 ])
-        else:
-            raise ConfigError("Unsupported deepsea install method '%s'"
-                                                % self.config['install'])
 
-        self.setup_salt()
+    def setup(self):
+        super(DeepSea, self).setup()
+        log.debug("beginning of DeepSea task setup method...")
+        pass
+        log.debug("end of DeepSea task setup...")
 
     def begin(self):
         super(DeepSea, self).begin()
-        self.salt.master_remote.run(args=[
+        log.debug("beginning of DeepSea task begin method...")
+        self.master_remote.run(args=[
             'sudo',
             'rpm',
             '-q',
@@ -188,76 +167,27 @@ class DeepSea(Task):
             ])
         suite_path = self.ctx.config.get('suite_path')
         log.info("suite_path is ->{}<-".format(suite_path))
-        log.info("deepsea task complete")
-
-    def purge_osds(self):
-        # replace this hack with DeepSea purge when it's ready
-        for _remote in self.ctx.cluster.remotes.iterkeys():
-            self.log.info("stopping OSD services on {}"
-                .format(_remote.hostname))
-            _remote.run(args=[
-                'sudo', 'sh', '-c',
-                'systemctl stop ceph-osd.target ; sleep 10'
-                ])
-            self.log.info("unmounting OSD partitions on {}"
-                .format(_remote.hostname))
-            # bluestore XFS partition is vd?1 - unmount up to five OSDs
-            _remote.run(args=[
-                'sudo', 'sh', '-c',
-                'for f in vdb1 vdc1 vdd1 vde1 vdf1 ; do test -b /dev/$f && umount /dev/$f || true ; done'
-                ])
-            # filestore XFS partition is vd?2 - unmount up to five OSDs
-            _remote.run(args=[
-                'sudo', 'sh', '-c',
-                'for f in vdb2 vdc2 vdd2 vde2 vdf2; do test -b /dev/$f && umount /dev/$f || true ; done'
-                ])
-
-    def gather_logs(self, logdir):
-        for _remote in self.ctx.cluster.remotes.iterkeys():
-            try:
-                _remote.run(args = [
-                    'sudo', 'test', '-d', '/var/log/{}/'.format(logdir),
-                    ])
-            except CommandFailedError:
-                continue
-            self.log.info("Gathering {} logs from remote {}"
-                .format(logdir, _remote.hostname))
-            _remote.run(args = [
-                'sudo', 'cp', '-a', '/var/log/{}/'.format(logdir),
-                '/home/ubuntu/cephtest/archive/',
-                run.Raw(';'),
-                'sudo', 'chown', '-R', 'ubuntu',
-                '/home/ubuntu/cephtest/archive/{}/'.format(logdir),
-                run.Raw(';'),
-                'find', '/home/ubuntu/cephtest/archive/{}/'.format(logdir),
-                '-type', 'f', '-print0',
-                run.Raw('|'),
-                'xargs', '-0', '--no-run-if-empty', '--', 'gzip', '--'
-                ])
-
-    def gather_logfile(self, logfile):
-        for _remote in self.ctx.cluster.remotes.iterkeys():
-            try:
-                _remote.run(args = [
-                    'sudo', 'test', '-f', '/var/log/{}'.format(logfile),
-                    ])
-            except CommandFailedError:
-                continue
-            self.log.info("Gathering logfile /var/log/{} from remote {}"
-                .format(logfile, _remote.hostname))
-            _remote.run(args = [
-                'sudo', 'cp', '-a', '/var/log/{}'.format(logfile),
-                '/home/ubuntu/cephtest/archive/',
-                run.Raw(';'),
-                'sudo', 'chown', 'ubuntu',
-                '/home/ubuntu/cephtest/archive/{}'.format(logfile)
-                ])
+        if self.config['install'] in ['source', 'src']:
+            self.__install_deepsea_from_source()
+        elif self.config['install'] in ['package', 'pkg']:
+            self.__install_deepsea_using_zypper()
+        else:
+            raise ConfigError("Unsupported deepsea install method '%s'"
+                                                % self.config['install'])
+        log.debug("end of DeepSea task begin method...")
 
     def end(self):
-        self.gather_logfile('deepsea.log')
-        self.purge_osds()
-        self.gather_logs('salt')
-        self.gather_logs('ganesha')
         super(DeepSea, self).end()
+        log.debug("beginning of DeepSea task end method...")
+        self.sm.gather_logfile('deepsea.log')
+        self.sm.gather_logs('ganesha')
+        log.debug("end of DeepSea task end method...")
+
+    def teardown(self):
+        super(DeepSea, self).teardown()
+        log.debug("beginning of DeepSea task teardown method...")
+        self.__purge_osds()
+        log.debug("end of DeepSea task teardown method...")
+
 
 task = DeepSea

--- a/qa/tasks/salt.py
+++ b/qa/tasks/salt.py
@@ -1,0 +1,207 @@
+'''
+Task that deploys a Salt cluster on all the nodes
+'''
+import logging
+import re
+
+from cStringIO import StringIO
+from netifaces import ifaddresses
+
+from salt_manager import SaltManager
+from teuthology.exceptions import (CommandFailedError, ConfigError)
+from teuthology.misc import delete_file, move_file, sh, sudo_write_file
+from teuthology.orchestra import run
+from teuthology.task import Task
+
+log = logging.getLogger(__name__)
+
+
+class Salt(Task):
+    """
+    Deploy a Salt cluster on all remotes (test nodes).
+    
+    This task assumes all relevant Salt packages (salt, salt-master, salt-minion,
+    salt-api, python-salt, etc. - whatever they may be called for the OS in
+    question) are already installed. This should be done using the install task.
+
+    One, and only one, of the machines must have a role corresponding to the
+    value of the variable salt.sm.master_role (see salt_manager.py). This node
+    is referred to as the "Salt Master", or the "master node".
+    
+    The task starts the Salt Master daemon on the master node, and Salt Minion
+    daemons on all the nodes (including the master node), and ensures that the
+    minions are properly linked to the master. Finally, it tries to ping all
+    the minions from the Salt Master.
+
+    :param ctx: the argparse.Namespace object
+    :param config: the config dict
+    """
+
+    def __init__(self, ctx, config):
+        super(Salt, self).__init__(ctx, config)
+        log.debug("Munged config is {}".format(self.config))
+        self.remotes = self.cluster.remotes
+        self.sm = SaltManager(self.ctx, self.config)
+
+    def __generate_minion_keys(self):
+        '''
+        Generate minion key on salt master to be used to preseed this cluster's
+        minions.
+        '''
+        for rem in self.remotes.iterkeys():
+            minion_id = rem.hostname
+            log.info('Ensuring that minion ID {} has a keypair on the master'
+                     .format(minion_id))
+            # mode 777 is necessary to be able to generate keys reliably
+            # we hit this before:
+            # https://github.com/saltstack/salt/issues/31565
+            self.sm.master_remote.run(args=[
+                'sudo',
+                'sh',
+                '-c',
+                'test -d salt || mkdir -m 777 salt',
+            ])
+            self.sm.master_remote.run(args=[
+                'sudo',
+                'sh',
+                '-c',
+                'test -d salt/minion-keys || mkdir -m 777 salt/minion-keys',
+            ])
+            self.sm.master_remote.run(args=[
+                'sudo',
+                'sh',
+                '-c',
+                ('if [ ! -f salt/minion-keys/{mid}.pem ]; then '
+                 'salt-key --gen-keys={mid} '
+                 '--gen-keys-dir=salt/minion-keys/; '
+                 ' fi').format(mid=minion_id),
+            ])
+
+    def __preseed_minions(self):
+        '''
+        Preseed minions with generated and accepted keys; set minion id
+        to the remote's hostname.
+        '''
+        for rem in self.remotes.iterkeys():
+            minion_id = rem.hostname
+            src = 'salt/minion-keys/{}.pub'.format(minion_id)
+            dest = '/etc/salt/pki/master/minions/{}'.format(minion_id)
+            self.sm.master_remote.run(args=[
+                'sudo',
+                'sh',
+                '-c',
+                ('if [ ! -f {d} ]; then '
+                'cp {s} {d} ; '
+                'chown root {d} ; '
+                'fi').format(s=src, d=dest)
+            ])
+            self.sm.master_remote.run(args=[
+                'sudo',
+                'chown',
+                'ubuntu',
+                'salt/minion-keys/{}.pem'.format(minion_id),
+                'salt/minion-keys/{}.pub'.format(minion_id),
+            ])
+            #
+            # copy the keys via the teuthology VM. The worker VMs can't ssh to
+            # each other. scp -3 does a 3-point copy through the teuthology VM.
+            sh('scp -3 {}:salt/minion-keys/{}.* {}:'.format(
+                self.sm.master_remote.name,
+                minion_id, rem.name))
+            sudo_write_file(rem, '/etc/salt/minion_id', minion_id)
+            #
+            # set proper owner and permissions on keys
+            rem.run(
+                args=[
+                    'sudo',
+                    'chown',
+                    'root',
+                    '{}.pem'.format(minion_id),
+                    '{}.pub'.format(minion_id),
+                    run.Raw(';'),
+                    'sudo',
+                    'chmod',
+                    '600',
+                    '{}.pem'.format(minion_id),
+                    run.Raw(';'),
+                    'sudo',
+                    'chmod',
+                    '644',
+                    '{}.pub'.format(minion_id),
+                ],
+            )
+            #
+            # move keys to correct location
+            move_file(rem, '{}.pem'.format(minion_id),
+                      '/etc/salt/pki/minion/minion.pem', sudo=True,
+                      preserve_perms=False)
+            move_file(rem, '{}.pub'.format(minion_id),
+                      '/etc/salt/pki/minion/minion.pub', sudo=True,
+                      preserve_perms=False)
+
+    def __set_minion_master(self):
+        """Points all minions to the master"""
+        master_id = self.sm.master_remote.hostname
+        for rem in self.remotes.iterkeys():
+            # remove old master public key if present. Minion will refuse to
+            # start if master name changed but old key is present
+            delete_file(rem, '/etc/salt/pki/minion/minion_master.pub',
+                        sudo=True, check=False)
+
+            # set master id
+            sed_cmd = ('echo master: {} > '
+                       '/etc/salt/minion.d/master.conf').format(master_id)
+            rem.run(args=[
+                'sudo',
+                'sh',
+                '-c',
+                sed_cmd,
+            ])
+
+    def __set_debug_log_level(self):
+        """Sets log_level: debug for all salt daemons"""
+        for rem in self.remotes.iterkeys():
+            rem.run(args=[
+                'sudo',
+                'sed', '--in-place', '--regexp-extended',
+                '-e', 's/^\s*#\s*log_level:.*$/log_level: debug/g',
+                '-e', '/^\s*#.*$/d', '-e', '/^\s*$/d',
+                '/etc/salt/master',
+                '/etc/salt/minion',
+            ])
+
+    def __provision_minions(self):
+        self.__generate_minion_keys()
+        self.__preseed_minions()
+        self.__set_minion_master()
+        self.__set_debug_log_level()
+        self.sm.start_master()
+
+    def setup(self):
+        super(Salt, self).setup()
+        log.debug("beginning of Salt task setup method")
+        self.__provision_minions()
+        log.debug("end of Salt task setup method")
+
+    def begin(self):
+        super(Salt, self).begin()
+        log.debug("beginning of Salt task begin method")
+        self.sm.start_minions()
+        self.sm.check_salt_daemons()
+        self.sm.ping_minions()
+        log.debug("end of Salt task begin method")
+
+    def end(self):
+        super(Salt, self).end()
+        log.debug("beginning of Salt task end method")
+        self.sm.gather_logs('salt')
+        log.debug("end of Salt task end method")
+    
+    def teardown(self):
+        super(Salt, self).teardown()
+        log.debug("beginning of Salt task teardown method")
+        pass
+        log.debug("end of Salt task teardown method")
+
+
+task = Salt

--- a/qa/tasks/salt_manager.py
+++ b/qa/tasks/salt_manager.py
@@ -1,0 +1,160 @@
+'''
+Salt "manager" module
+
+Usage: First, ensure that there is a role whose name corresponds
+to the value of the master_role variable, below. Second, in your
+task, instantiate a SaltManager object:
+
+    from salt_manager import SaltManager
+
+    sm = SaltManager(ctx, config)
+
+Third, enjoy the SaltManager goodness - e.g.:
+
+    sm.ping_minions()
+
+'''
+import logging
+import re
+
+from cStringIO import StringIO
+from teuthology import misc
+from teuthology.contextutil import safe_while
+from teuthology.exceptions import (CommandFailedError, ConfigError)
+from teuthology.orchestra.remote import Remote
+from teuthology.orchestra import run
+from util import get_remote_for_role
+
+log = logging.getLogger(__name__)
+master_role = 'client.salt_master'
+
+
+class SaltManager(object):
+
+    def __init__(self, ctx, config):
+        config["master_remote"] = get_remote_for_role(ctx, master_role).name
+        self.config = config
+        self.ctx = ctx
+        self.cluster = ctx.cluster
+        self.master_remote = Remote(self.config.get('master_remote'))
+        self.remotes = ctx.cluster.remotes
+
+    def __systemctl_cluster(self, subcommand=None, service=None):
+        """
+        Do something to a systemd service unit on all remotes (test nodes) at
+        once
+        """
+        self.cluster.run(args=[
+            'sudo', 'systemctl', subcommand, '{}.service'.format(service)])
+
+    def __systemctl_remote(self, remote, subcommand=None, service=None):
+        """
+        Do something to a systemd service unit on a single remote (test node)
+        """
+        try:
+            remote.run(args=[
+                'sudo', 'systemctl', subcommand, '{}.service'.format(service)])
+        except CommandFailedError:
+            log.warning("Failed to {} {}.service!".format(subcommand, service))
+            remote.run(args=[
+                'sudo', 'systemctl', 'status', '--full', '--lines=50',
+                '{}.service'.format(service), run.Raw('||'), 'true'])
+            raise
+
+    def __ping(self, ping_cmd, expected):
+        with safe_while(sleep=15, tries=20,
+                        action=ping_cmd) as proceed:
+            while proceed():
+                output = StringIO()
+                self.master_remote.run(args=ping_cmd, stdout=output)
+                responded = len(re.findall('True', output.getvalue()))
+                log.debug('{} minion(s) responded'.format(responded))
+                output.close()
+                if (expected == responded):
+                    return None
+
+    def check_salt_daemons(self):
+        self.master_remote.run(args = ['sudo', 'salt-key', '-L'])
+        self.master_remote.run(args = ['sudo', 'systemctl', 'status',
+                'salt-master.service'])
+        for _remote in self.ctx.cluster.remotes.iterkeys():
+            _remote.run(args = ['sudo', 'systemctl', 'status',
+                'salt-minion.service'])
+            _remote.run(args = ['sudo', 'cat', '/etc/salt/minion_id'])
+            _remote.run(args = ['sudo', 'cat', '/etc/salt/minion.d/master.conf'])
+
+    def gather_logs(self, logdir):
+        for _remote in self.ctx.cluster.remotes.iterkeys():
+            try:
+                _remote.run(args = [
+                    'sudo', 'test', '-d', '/var/log/{}/'.format(logdir),
+                    ])
+            except CommandFailedError:
+                continue
+            log.info("Gathering {} logs from remote {}"
+                .format(logdir, _remote.hostname))
+            _remote.run(args = [
+                'sudo', 'cp', '-a', '/var/log/{}/'.format(logdir),
+                '/home/ubuntu/cephtest/archive/',
+                run.Raw(';'),
+                'sudo', 'chown', '-R', 'ubuntu',
+                '/home/ubuntu/cephtest/archive/{}/'.format(logdir),
+                run.Raw(';'),
+                'find', '/home/ubuntu/cephtest/archive/{}/'.format(logdir),
+                '-type', 'f', '-print0',
+                run.Raw('|'),
+                'xargs', '-0', '--no-run-if-empty', '--', 'gzip', '--'
+                ])
+
+    def gather_logfile(self, logfile):
+        for _remote in self.ctx.cluster.remotes.iterkeys():
+            try:
+                _remote.run(args = [
+                    'sudo', 'test', '-f', '/var/log/{}'.format(logfile),
+                    ])
+            except CommandFailedError:
+                continue
+            log.info("Gathering logfile /var/log/{} from remote {}"
+                .format(logfile, _remote.hostname))
+            _remote.run(args = [
+                'sudo', 'cp', '-a', '/var/log/{}'.format(logfile),
+                '/home/ubuntu/cephtest/archive/',
+                run.Raw(';'),
+                'sudo', 'chown', 'ubuntu',
+                '/home/ubuntu/cephtest/archive/{}'.format(logfile)
+                ])
+
+    def master_role(self):
+        return master_role
+
+    def ping_minion(self, mid):
+        """Pings a minion; raises exception if it doesn't respond"""
+        self.__ping(['sudo', 'salt', mid, 'test.ping'], 1)
+
+    def ping_minions(self):
+        """
+        Pings minions; raises exception if they don't respond
+        """
+        self.__ping(
+            [
+            'sudo', 'sh', '-c', 'salt \* test.ping || true',
+            ],
+            len(self.remotes))
+
+    def start_minions(self):
+        """Starts salt-minion.service on all cluster nodes"""
+        self.__systemctl_cluster(subcommand="start", service="salt-minion")
+
+    def restart_minions(self):
+        """Restarts salt-minion.service on all cluster nodes"""
+        self.__systemctl_cluster(subcommand="restart", service="salt-minion")
+
+    def start_master(self):
+        """Starts salt-master.service on the Salt Master node"""
+        self.__systemctl_remote(self.master_remote,
+            subcommand="start", service="salt-master")
+
+    def restart_master(self):
+        """Starts salt-master.service on the Salt Master node"""
+        self.__systemctl_remote(self.master_remote,
+            subcommand="restart", service="salt-master")

--- a/qa/workunits/deepsea/common/helper.sh
+++ b/qa/workunits/deepsea/common/helper.sh
@@ -169,13 +169,12 @@ function _root_fs_is_btrfs {
 }
 
 function _ping_minions_until_all_respond {
-    local NUM_MINIONS="$1"
     local RESPONDING=""
     for i in {1..20} ; do
         sleep 10
         RESPONDING=$(salt '*' test.ping 2>/dev/null | grep True 2>/dev/null | wc --lines)
-        echo "Of $NUM_MINIONS total minions, $RESPONDING are responding"
-        test "$NUM_MINIONS" -eq "$RESPONDING" && break
+        echo "Of $TOTAL_NODES total minions, $RESPONDING are responding"
+        test "$TOTAL_NODES" -eq "$RESPONDING" && break
     done
 }
 


### PR DESCRIPTION
and add salt_manager.py helper module used by both the Salt and DeepSea tasks. This will be joined by a teuthology companion PR.

To Do:
- [x] open teuthology companion PR https://github.com/SUSE/teuthology/pull/141
- [x] https://github.com/SUSE/teuthology/pull/140 merged
- [x] add salt task everywhere in deepsea suite yaml
- [x] install Salt RPMs via extra_system_packages option to install task (everywhere in deepsea suite yaml)
- [x] passes `--suite deepsea/tier0`
- [x] https://github.com/SUSE/teuthology/pull/154 merged
- [x] passes `--suite suse`
- [x] mop-up (see comments in-line)