### PR TITLE
rgw: url_encode key name and instance in es sync module

### DIFF
--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -149,7 +149,7 @@ struct ElasticConfig {
   }
 
   string get_obj_path(const RGWBucketInfo& bucket_info, const rgw_obj_key& key) {
-    return index_path +  "/object/" + bucket_info.bucket.bucket_id + ":" + key.name + ":" + (key.instance.empty() ? "null" : key.instance);
+    return index_path +  "/object/" + url_encode(bucket_info.bucket.bucket_id + ":" + key.name + ":" + (key.instance.empty() ? "null" : key.instance));
   }
 
   bool should_handle_operation(RGWBucketInfo& bucket_info) {


### PR DESCRIPTION
bsc#1110416

---

Some objects whose name contains space or other special chars
can't be synced to ES correctly. we need to do url_encode when
we send a HTTP request to ES.

Fixes: tracker.ceph.com/issues/23216
bsc#1110416
Signed-off-by: Chang Liu <liuchang0812@gmail.com>
(cherry picked from commit 13978bb28b7be809033bf24550b21ed2713ddc9b)