### PR TITLE
ses5 es fixes

### DIFF
--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -149,7 +149,7 @@ struct ElasticConfig {
   }
 
   string get_obj_path(const RGWBucketInfo& bucket_info, const rgw_obj_key& key) {
-    return index_path +  "/object/" + bucket_info.bucket.bucket_id + ":" + key.name + ":" + (key.instance.empty() ? "null" : key.instance);
+    return index_path +  "/object/" + url_encode(bucket_info.bucket.bucket_id + ":" + key.name + ":" + (key.instance.empty() ? "null" : key.instance));
   }
 
   bool should_handle_operation(RGWBucketInfo& bucket_info) {

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -309,7 +309,7 @@ struct es_obj_metadata {
       } else if (name == "compression") {
         RGWCompressionInfo cs_info;
         auto vals_bl = val.begin();
-        decode(cs_info, vals_bl);
+        ::decode(cs_info, vals_bl);
         out_attrs[name] = cs_info.compression_type;
       } else {
         if (name != "pg_ver" &&

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -243,6 +243,19 @@ struct es_index_config {
   }
 };
 
+static bool is_sys_attr(const std::string& attr_name){
+  static constexpr std::initializer_list<const char*> rgw_sys_attrs = {RGW_ATTR_PG_VER,
+                                                                       RGW_ATTR_SOURCE_ZONE,
+                                                                       RGW_ATTR_ID_TAG,
+                                                                       RGW_ATTR_TEMPURL_KEY1,
+                                                                       RGW_ATTR_TEMPURL_KEY2,
+                                                                       RGW_ATTR_UNIX1,
+                                                                       RGW_ATTR_UNIX_KEY1
+  };
+
+  return std::find(rgw_sys_attrs.begin(), rgw_sys_attrs.end(), attr_name) != rgw_sys_attrs.end();
+}
+
 struct es_obj_metadata {
   CephContext *cct;
   ElasticConfigRef es_conf;
@@ -267,7 +280,6 @@ struct es_obj_metadata {
 
     for (auto i : attrs) {
       const string& attr_name = i.first;
-      string name;
       bufferlist& val = i.second;
 
       if (attr_name.compare(0, sizeof(RGW_ATTR_PREFIX) - 1, RGW_ATTR_PREFIX) != 0) {
@@ -275,14 +287,16 @@ struct es_obj_metadata {
       }
 
       if (attr_name.compare(0, sizeof(RGW_ATTR_META_PREFIX) - 1, RGW_ATTR_META_PREFIX) == 0) {
-        name = attr_name.substr(sizeof(RGW_ATTR_META_PREFIX) - 1);
-        custom_meta[name] = string(val.c_str(), (val.length() > 0 ? val.length() - 1 : 0));
+        custom_meta.emplace(attr_name.substr(sizeof(RGW_ATTR_META_PREFIX) - 1),
+                            string(val.c_str(), (val.length() > 0 ? val.length() - 1 : 0)));
         continue;
       }
 
-      name = attr_name.substr(sizeof(RGW_ATTR_PREFIX) - 1);
+      if (attr_name.compare(0, sizeof(RGW_ATTR_CRYPT_PREFIX) -1, RGW_ATTR_CRYPT_PREFIX) == 0) {
+        continue;
+      }
 
-      if (name == "acl") {
+      if (attr_name == RGW_ATTR_ACL) {
         try {
           auto i = val.begin();
           ::decode(policy, i);
@@ -303,19 +317,18 @@ struct es_obj_metadata {
             }
           }
         }
-      } else if (name == "x-amz-tagging") {
-        auto tags_bl = val.begin();
+      } else if (attr_name == RGW_ATTR_TAGS) {
+        auto tags_bl = val.cbegin();
         ::decode(obj_tags, tags_bl);
-      } else if (name == "compression") {
+      } else if (attr_name == RGW_ATTR_COMPRESSION) {
         RGWCompressionInfo cs_info;
-        auto vals_bl = val.begin();
+        auto vals_bl = val.cbegin();
         ::decode(cs_info, vals_bl);
-        out_attrs[name] = cs_info.compression_type;
+        out_attrs.emplace("compression",std::move(cs_info.compression_type));
       } else {
-        if (name != "pg_ver" &&
-            name != "source_zone" &&
-            name != "idtag") {
-          out_attrs[name] = string(val.c_str(), (val.length() > 0 ? val.length() - 1 : 0));
+        if (!is_sys_attr(attr_name)) {
+          out_attrs.emplace(attr_name.substr(sizeof(RGW_ATTR_PREFIX) - 1),
+                            std::string(val.c_str(), (val.length() > 0 ? val.length() - 1 : 0)));
         }
       }
     }

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -302,6 +302,7 @@ struct es_obj_metadata {
           ::decode(policy, i);
         } catch (buffer::error& err) {
           ldout(cct, 0) << "ERROR: failed to decode acl for " << bucket_info.bucket << "/" << key << dendl;
+          continue;
         }
 
         const RGWAccessControlList& acl = policy.get_acl();
@@ -318,12 +319,24 @@ struct es_obj_metadata {
           }
         }
       } else if (attr_name == RGW_ATTR_TAGS) {
-        auto tags_bl = val.cbegin();
-        ::decode(obj_tags, tags_bl);
+        try {
+          auto tags_bl = val.begin();
+          ::decode(obj_tags, tags_bl);
+        } catch (buffer::error& err) {
+          ldout(cct,0) << "ERROR: failed to decode obj tags for "
+                       << bucket_info.bucket << "/" << key << dendl;
+          continue;
+        }
       } else if (attr_name == RGW_ATTR_COMPRESSION) {
         RGWCompressionInfo cs_info;
-        auto vals_bl = val.cbegin();
-        ::decode(cs_info, vals_bl);
+        try {
+          auto vals_bl = val.begin();
+          ::decode(cs_info, vals_bl);
+        } catch (buffer::error& err) {
+          ldout(cct,0) << "ERROR: failed to decode compression attr for "
+                       << bucket_info.bucket << "/" << key << dendl;
+          continue;
+        }
         out_attrs.emplace("compression",std::move(cs_info.compression_type));
       } else {
         if (!is_sys_attr(attr_name)) {


### PR DESCRIPTION
bsc#1110415
bsc#1110416

--
Set of 2 fixes:
* Some objects whose name contains space or other special chars
can't be synced to ES correctly. we need to do url_encode when
we send a HTTP request to ES.

Fixes: tracker.ceph.com/issues/23216
bsc#1110416

* Drop system attributes like url-keys, nfs-ganesha unix keys,
encryption keys and other system attributes when uploading metadata to ES.
This also brings in a tiny change where the attribute substring is no longer
compared and we compare the whole attribute name against the constants in
rgw_common

Fixes:http://tracker.ceph.com/issues/36233