### PR TITLE
qa/tasks/deepsea_deploy.py: implement built-in Stage 0 capability 

### DIFF
--- a/qa/deepsea/health-ok/common/deploy.sh
+++ b/qa/deepsea/health-ok/common/deploy.sh
@@ -162,13 +162,13 @@ function deploy_ceph {
         _zypper_ps
         salt_api_test
     fi
-    if [ "$TEUTHOLOGY" ] ; then
-        echo "Development work in progress: finishing early!"
-        exit 0
-    fi
     if [ "$START_STAGE" -le "1" ] ; then
         test -n "$RGW" -a -n "$SSL" && rgw_ssl_init
         run_stage_1 "$CLI"
+        if [ "$TEUTHOLOGY" ] ; then
+            echo "Development work in progress: finishing early!"
+            exit 0
+        fi
         policy_cfg_base
         policy_cfg_mon_flex
         test -n "$MDS" && policy_cfg_mds

--- a/qa/suites/deepsea/test/tasks1-deepsea.yaml
+++ b/qa/suites/deepsea/test/tasks1-deepsea.yaml
@@ -2,3 +2,7 @@ tasks:
   - deepsea:
       install: package
   - deepsea_deploy:
+      cli: true
+      commands:
+        - stage0:
+        - 'health-ok.sh --teuthology --cli --start-stage=1'

--- a/qa/tasks/salt.py
+++ b/qa/tasks/salt.py
@@ -170,23 +170,21 @@ class Salt(Task):
                 '/etc/salt/minion',
             ])
 
-    def __provision_minions(self):
+    def setup(self):
+        super(Salt, self).setup()
+        log.debug("beginning of Salt task setup method")
         self.__generate_minion_keys()
         self.__preseed_minions()
         self.__set_minion_master()
         self.__set_debug_log_level()
         self.sm.start_master()
-
-    def setup(self):
-        super(Salt, self).setup()
-        log.debug("beginning of Salt task setup method")
-        self.__provision_minions()
+        self.sm.start_minions()
+        self.sm.restart_master()
         log.debug("end of Salt task setup method")
 
     def begin(self):
         super(Salt, self).begin()
         log.debug("beginning of Salt task begin method")
-        self.sm.start_minions()
         self.sm.check_salt_daemons()
         self.sm.ping_minions()
         log.debug("end of Salt task begin method")

--- a/qa/tasks/salt_manager.py
+++ b/qa/tasks/salt_manager.py
@@ -79,7 +79,7 @@ class SaltManager(object):
             log.warning("{} not found on {}".format(filename, remote.name))
 
     def __ping(self, ping_cmd, expected):
-        with safe_while(sleep=15, tries=20,
+        with safe_while(sleep=15, tries=50,
                         action=ping_cmd) as proceed:
             while proceed():
                 output = StringIO()
@@ -156,6 +156,18 @@ class SaltManager(object):
         except CommandFailedError:
             installed = False
         return installed
+
+    def all_minions_zypper_ps(self):
+        """Run "zypper ps -s" on all nodes"""
+        self.master_remote.run(args=[
+            'sudo',
+            'salt',
+            '*',
+            'cmd.run',
+            'zypper ps -s',
+            run.Raw('||'),
+            'true',
+            ])
 
     def ping_minion(self, mid):
         """Pings a minion; raises exception if it doesn't respond"""


### PR DESCRIPTION
Feature-parity with health-ok.sh achieved.
See qa/suites/deepsea/test/tasks1-deepsea.yaml for how to use.

---

- [x] passes `--suite deepsea/test` `suite_sha1: ab955d554ad8896c8c1914de540d1c6238368ad7`
- [x] passes `--suite deepsea/tier0` `suite_sha1: ab955d554ad8896c8c1914de540d1c6238368ad7`