### PR TITLE
qa/deepsea_deploy: implement Stage 1 (fully) and Stage 2 (partially)

### DIFF
--- a/qa/deepsea/health-ok/common/deploy.sh
+++ b/qa/deepsea/health-ok/common/deploy.sh
@@ -165,10 +165,6 @@ function deploy_ceph {
     if [ "$START_STAGE" -le "1" ] ; then
         test -n "$RGW" -a -n "$SSL" && rgw_ssl_init
         run_stage_1 "$CLI"
-        if [ "$TEUTHOLOGY" ] ; then
-            echo "Development work in progress: finishing early!"
-            exit 0
-        fi
         policy_cfg_base
         policy_cfg_mon_flex
         test -n "$MDS" && policy_cfg_mds

--- a/qa/deepsea/health-ok/health-ok.sh
+++ b/qa/deepsea/health-ok/health-ok.sh
@@ -149,6 +149,10 @@ set -x
 
 # deploy phase
 deploy_ceph
+if [ "$TEUTHOLOGY" ] ; then
+    echo "Development work underway: finishing early!"
+    exit 0
+fi
 
 # verification phase
 ceph_health_test

--- a/qa/suites/deepsea/test/cluster/0disks.yaml
+++ b/qa/suites/deepsea/test/cluster/0disks.yaml
@@ -1,1 +1,0 @@
-.qa/deepsea/disks/0disks.yaml

--- a/qa/suites/deepsea/test/cluster/3disks.yaml
+++ b/qa/suites/deepsea/test/cluster/3disks.yaml
@@ -1,0 +1,1 @@
+.qa/deepsea/disks/3disks.yaml

--- a/qa/suites/deepsea/test/cluster/test_roles.yaml
+++ b/qa/suites/deepsea/test/cluster/test_roles.yaml
@@ -1,4 +1,4 @@
 roles:
-- [client.salt_master, mon.a, mgr.x]
-- [igw.0, rgw.5]
+- [client.salt_master, mon.a, mgr.x, osd.0]
+- [igw.0, rgw.5, osd.1]
 - [client.0]

--- a/qa/suites/deepsea/test/tasks1-deepsea.yaml
+++ b/qa/suites/deepsea/test/tasks1-deepsea.yaml
@@ -5,4 +5,6 @@ tasks:
       cli: true
       commands:
         - stage0:
-        - 'health-ok.sh --teuthology --cli --start-stage=1'
+        - stage1:
+        - stage2:
+        - 'health-ok.sh --teuthology --cli --start-stage=3'

--- a/qa/tasks/salt.py
+++ b/qa/tasks/salt.py
@@ -186,6 +186,8 @@ class Salt(Task):
         super(Salt, self).begin()
         log.debug("beginning of Salt task begin method")
         self.sm.check_salt_daemons()
+        self.sm.cat_salt_master_conf()
+        self.sm.cat_salt_minion_confs()
         self.sm.ping_minions()
         log.debug("end of Salt task begin method")
 

--- a/qa/tasks/util/__init__.py
+++ b/qa/tasks/util/__init__.py
@@ -1,4 +1,5 @@
 from teuthology import misc
+from teuthology.orchestra import run
 
 def check_config_key(conf_dict, keyname, default_value):
     """
@@ -44,3 +45,20 @@ def copy_directory_recursively(from_path, to_remote, to_path=None):
     misc.sh("scp -r -v {from_path} {host}:{to_path}".format(
             from_path=from_path, host=to_remote.name, to_path=to_path))
 
+def sudo_append_to_file(remote, path, data):
+    """
+    Append data to a remote file
+
+    :param remote: Remote site.
+    :param path: Path on the remote being written to.
+    :param data: Data to be written.
+    """
+    remote.run(
+        args=[
+            'sudo',
+            'sh',
+            '-c',
+            'cat >> ' + path,
+        ],
+        stdin=data,
+    )

--- a/qa/tasks/util/__init__.py
+++ b/qa/tasks/util/__init__.py
@@ -47,11 +47,13 @@ def copy_directory_recursively(from_path, to_remote, to_path=None):
 
 def sudo_append_to_file(remote, path, data):
     """
-    Append data to a remote file
+    Append data to a remote file. Standard 'cat >>' - creates file
+    if it doesn't exist, but all directory components in the file
+    path must exist.
 
     :param remote: Remote site.
     :param path: Path on the remote being written to.
-    :param data: Data to be written.
+    :param data: Python string containing data to be written.
     """
     remote.run(
         args=[


### PR DESCRIPTION
Implementation of Stage 1 is complete. Stage 2 is still missing a lot - notably, non-default storage profiles. Also, currently the "default profile" deploys OSDs on all eligible disks on every storage node. This is non-intuitive, because the roles stanza (in the teutholoy job yaml) expects to specify the number of osd roles (OSDs) on the individual test nodes.

---

- [x] passes `--suite deepsea/test`
- [x] passes `--suite deepsea/tier1` (to assert that this PR doesn't break the workunit-based tests)
- [x] review comments addressed in next PR