### PR TITLE
qa/deepsea_deploy: new task or directive to add custom ceph config

### DIFF
--- a/qa/suites/deepsea/test/functional/tasks/deploy-and-test.yaml
+++ b/qa/suites/deepsea/test/functional/tasks/deploy-and-test.yaml
@@ -7,6 +7,14 @@ tasks:
         - policy_cfg:
             profile: default
         - stage2:
+        - custom_ceph_conf:
+            global:
+              mon lease: 15
+              mon lease ack timeout: 25
+            mon:
+              debug mon: 20
+            osd:
+              debug filestore: 20
         - stage3:
         - stage4:
         - 'ceph -s'


### PR DESCRIPTION
adding the `custom_ceph_conf` option in deepsea_deploy tasks, between stage 2 and 3 like this: 

```yaml
tasks:
  - deepsea_deploy:
      cli: true
      commands:
        - stage0:
            update: false
        - stage1:
        - policy_cfg:
            profile: default
        - stage2:
        - custom_ceph_conf:
            global:
              mon lease: 15
              mon lease ack timeout: 25
            mon:
              debug mon: 20
            osd:
              debug filestore: 20
        - stage3:
```