### PR TITLE
[SES5] qa: introducing the deepsea.repository subtask and automated upgrade testing

### DIFF
--- a/qa/deepsea/stage4.yaml
+++ b/qa/deepsea/stage4.yaml
@@ -1,4 +1,0 @@
-tasks:
-        - deepsea.create_pools:
-        - deepsea.orch:
-                stage: 4

--- a/qa/suites/deepsea/tier4/upgrade/2-pools-and-services.yaml
+++ b/qa/suites/deepsea/tier4/upgrade/2-pools-and-services.yaml
@@ -1,1 +1,5 @@
-.qa/deepsea/stage4.yaml
+tasks:
+        - deepsea.create_pools:
+                cephfs:
+        - deepsea.orch:
+                stage: 4

--- a/qa/suites/deepsea/tier4/upgrade/3-test-phase.yaml
+++ b/qa/suites/deepsea/tier4/upgrade/3-test-phase.yaml
@@ -1,9 +1,31 @@
 tasks:
         - exec:
                 client.salt_master:
+                        - 'ceph --version'
                         - 'ceph -s'
         - deepsea.validation:
+                deepsea_install_method:
+                        package:
+        - deepsea.repository:
+                client.salt_master:
+        - exec:
+                client.salt_master:
+                        - 'zypper --non-interactive --no-gpg-checks rm gvfs-backends sle-sdk-release-POOL || true'
+        - exec:
+                client.salt_master:
+                        - 'zypper --non-interactive --no-gpg-checks dup --auto-agree-with-licenses --replacefiles'
+        - deepsea.reboot:
+                client.salt_master:
+        - deepsea.repository:
+                all:
+        - exec:
+                all:
+                        - 'zypper --non-interactive --no-gpg-checks rm gvfs-backends sle-sdk-release-POOL || true'
         - deepsea.state:
                 state: ceph.updates.salt
         - deepsea.orch:
                 state_orch: ceph.maintenance.upgrade
+        - exec:
+                client.salt_master:
+                        - 'ceph --version'
+                        - 'ceph -s'

--- a/qa/suites/deepsea/tier4/upgrade/3-test-phase.yaml
+++ b/qa/suites/deepsea/tier4/upgrade/3-test-phase.yaml
@@ -21,8 +21,10 @@ tasks:
         - exec:
                 all:
                         - 'zypper --non-interactive --no-gpg-checks rm gvfs-backends sle-sdk-release-POOL || true'
-        - deepsea.state:
-                state: ceph.updates.salt
+        - salt.command:
+                command: 'state.apply ceph.updates.salt'
+        - salt.command:
+                command: 'saltutil.sync_all'
         - deepsea.orch:
                 state_orch: ceph.maintenance.upgrade
         - exec:

--- a/qa/suites/deepsea/tier4/upgrade/cluster/roles.yaml
+++ b/qa/suites/deepsea/tier4/upgrade/cluster/roles.yaml
@@ -1,2 +1,3 @@
 roles:
-  - [client.salt_master, mon.a, mgr.x, osd.0]
+  - [client.salt_master]
+  - [mon.a, mgr.x, osd.0, mds.0, rgw.0]

--- a/qa/suites/deepsea/tier4/upgrade/deepsea_cli
+++ b/qa/suites/deepsea/tier4/upgrade/deepsea_cli
@@ -1,1 +1,0 @@
-.qa/deepsea/cli

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -34,6 +34,7 @@ from teuthology.contextutil import safe_while
 log = logging.getLogger(__name__)
 deepsea_ctx = {}
 proposals_dir = "/srv/pillar/ceph/proposals"
+reboot_tries = 15
 
 
 def anchored(log_message):
@@ -167,6 +168,7 @@ class DeepSea(Task):
         self.dashboard_ssl = deepsea_ctx['dashboard_ssl']
         self.deepsea_cli = deepsea_ctx['cli']
         self.dev_env = self.ctx['dev_env']
+        self.install_method = deepsea_ctx['install_method']
         self.log_anchor = deepsea_ctx['log_anchor']
         self.master_remote = deepsea_ctx['master_remote']
         self.nodes = self.ctx['nodes']
@@ -174,6 +176,7 @@ class DeepSea(Task):
         self.nodes_storage_only = self.ctx['nodes_storage_only']
         self.quiet_salt = deepsea_ctx['quiet_salt']
         self.remotes = self.ctx['remotes']
+        self.repositories = deepsea_ctx['repositories']
         self.rgw_ssl = deepsea_ctx['rgw_ssl']
         self.roles = self.ctx['roles']
         self.role_types = self.ctx['role_types']
@@ -382,6 +385,7 @@ class DeepSea(Task):
         deepsea_ctx['master_remote'] = (
                 deepsea_ctx['salt_manager_instance'].master_remote
                 )
+        deepsea_ctx['repositories'] = self.config.get("repositories", None)
         deepsea_ctx['rgw_ssl'] = self.config.get('rgw_ssl', False)
         if 'install' in self.config:
             if self.config['install'] in ['package', 'pkg']:
@@ -431,7 +435,22 @@ class DeepSea(Task):
         os_version = float(self.ctx.config.get('os_version', 0))
         return (os_type, os_version)
 
+    def reboot_a_single_machine_now(self, remote, log_spec=None):
+        global reboot_tries
+        if not log_spec:
+            log_spec = "node {} reboot now".format(remote.hostname)
+        cmd_str = "sudo reboot"
+        remote_exec(
+            remote,
+            cmd_str,
+            log_spec,
+            rerun=False,
+            quiet=True,
+            tries=reboot_tries,
+            )
+
     def reboot_the_cluster_now(self, log_spec=None):
+        global reboot_tries
         if not log_spec:
             log_spec = "all nodes reboot now"
         cmd_str = "salt \\* cmd.run reboot"
@@ -443,7 +462,7 @@ class DeepSea(Task):
             log_spec,
             rerun=False,
             quiet=True,
-            tries=5,
+            tries=reboot_tries,
             )
         self.sm.ping_minions()
 
@@ -974,6 +993,7 @@ class Orch(DeepSea):
 
     def _run_orch(self, orch_tuple):
         """Run an orchestration. Dump journalctl on error."""
+        global reboot_tries
         orch_type, orch_spec = orch_tuple
         if orch_type == 'orch':
             pass
@@ -1003,7 +1023,7 @@ class Orch(DeepSea):
             cmd_str = 'DEV_ENV=true ' + cmd_str
         tries = 0
         if self.survive_reboots:
-            tries = 5
+            tries = reboot_tries
         remote_exec(
             self.master_remote,
             cmd_str,
@@ -1354,8 +1374,24 @@ class Policy(DeepSea):
 
 class Reboot(DeepSea):
     """
-    A class that does nothing but unconditionally reboot the whole cluster.
+    A class that does nothing but unconditionally reboot, either a single node
+    or the whole cluster.
+
+    Configuration (reboot a single node)
+
+    tasks:
+    - deepsea.reboot:
+          client.salt_master:
+
+    Configuration (reboot the entire cluster)
+
+    tasks:
+    - deepsea.reboot:
+          all:
     """
+
+    err_prefix = '(reboot subtask) '
+
     def __init__(self, ctx, config):
         global deepsea_ctx
         deepsea_ctx['logger_obj'] = log.getChild('reboot')
@@ -1363,9 +1399,128 @@ class Reboot(DeepSea):
         super(Reboot, self).__init__(ctx, config)
 
     def begin(self):
-        log_spec = "all nodes reboot now"
-        self.log.warning(anchored(log_spec))
-        self.reboot_the_cluster_now(log_spec=log_spec)
+        if not self.config:
+            self.log.warning("empty config: nothing to do")
+            return None
+        config_keys = len(self.config)
+        if config_keys > 1:
+            raise ConfigError(
+                self.err_prefix +
+                "config dictionary may contain only one key. "
+                "You provided ->{}<- keys ({})".format(len(config_keys), config_keys)
+                )
+        role_spec, repositories = self.config.items()[0]
+        if role_spec == "all":
+            remote = self.ctx.cluster
+            log_spec = "all nodes reboot now"
+            self.log.warning(anchored(log_spec))
+            self.reboot_the_cluster_now(log_spec=log_spec)
+        else:
+            remote = get_remote_for_role(self.ctx, role_spec)
+            log_spec = "node {} reboot now".format(remote.hostname)
+            self.log.warning(anchored(log_spec))
+            self.reboot_a_single_machine_now(remote, log_spec=log_spec)
+
+    def end(self):
+        pass
+
+    def teardown(self):
+        pass
+
+
+class Repository(DeepSea):
+    """
+    A class for manipulating zypper repos on the test nodes.
+    All it knows how to do is wipe out the existing repos (i.e. rename them to
+    foo.repo.bck) and replace them with a given set of new ones.
+
+    Configuration (one node):
+
+    tasks:
+    - deepsea.repository:
+          client.salt_master:
+              - name: repo_foo
+                url: http://example.com/foo/
+              - name: repo_bar
+                url: http://example.com/bar/
+
+    Configuration (all nodes):
+
+    tasks:
+    - deepsea.repository:
+          all:
+              - name: repo_foo
+                url: http://example.com/foo/
+              - name: repo_bar
+                url: http://example.com/bar/
+
+    To eliminate the need to duplicate the repos array, it can be specified
+    in the configuration of the main deepsea task. Then the yaml will look
+    like so:
+
+    tasks:
+    - deepsea:
+          repositories:
+              - name: repo_foo
+                url: http://example.com/foo/
+              - name: repo_bar
+                url: http://example.com/bar/
+    ...
+    - deepsea.repository:
+          client.salt_master:
+    ...
+    - deepsea.repository:
+          all:
+
+    One last note: we try to be careful and not clobber the repos twice.
+    """
+
+    err_prefix = '(repository subtask) '
+
+    def __init__(self, ctx, config):
+        deepsea_ctx['logger_obj'] = log.getChild('repository')
+        self.name = 'deepsea.repository'
+        super(Repository, self).__init__(ctx, config)
+
+    def _repositories_to_remote(self, remote):
+        args = []
+        for repo in self.repositories:
+            args += [repo['name'] + ':' + repo['url']]
+        self.scripts.run(
+            remote,
+            'clobber_repositories.sh',
+            args=args
+            )
+
+    def begin(self):
+        if not self.config:
+            self.log.warning("empty config: nothing to do")
+            return None
+        config_keys = len(self.config)
+        if config_keys > 1:
+            raise ConfigError(
+                self.err_prefix +
+                "config dictionary may contain only one key. "
+                "You provided ->{}<- keys ({})".format(len(config_keys), config_keys)
+                )
+        role_spec, repositories = self.config.items()[0]
+        if role_spec == "all":
+            remote = self.ctx.cluster
+        else:
+            remote = get_remote_for_role(self.ctx, role_spec)
+        if repositories is None:
+            assert self.repositories, \
+                "self.repositories must be populated if role_dict is None"
+        else:
+            assert isinstance(repositories, list), \
+                "value of role key must be a list of repositories"
+            self.repositories = repositories
+        if not self.repositories:
+            raise ConfigError(
+                self.err_prefix +
+                "No repositories specified. Bailing out!"
+                )
+        self._repositories_to_remote(remote)
 
     def end(self):
         pass
@@ -1413,7 +1568,7 @@ class Script(DeepSea):
             raise ConfigError(
                 self.err_prefix +
                 "config dictionary may contain only one key. "
-                "You provided ->{}<- keys ({}}".format(len(config_keys), config_keys)
+                "You provided ->{}<- keys ({})".format(len(config_keys), config_keys)
                 )
         role_spec, role_dict = self.config.items()[0]
         role_keys = len(role_dict)
@@ -1421,7 +1576,7 @@ class Script(DeepSea):
             raise ConfigError(
                 self.err_prefix +
                 "role dictionary may contain only one key. "
-                "You provided ->{}<- keys ({}}".format(len(role_keys), role_keys)
+                "You provided ->{}<- keys ({})".format(len(role_keys), role_keys)
                 )
         if role_spec == "all":
             remote = self.ctx.cluster
@@ -1550,6 +1705,31 @@ class Validation(DeepSea):
             'ceph_version_sanity.sh',
             )
 
+    def deepsea_install_method(self, **kwargs):
+        """
+        Takes a single kwargs key, which is mandatory and can be
+        either "package" or "source".
+        """
+        config_err = (
+            self.err_prefix +
+            "deepsea_install_method takes a single config key, "
+            "which must be either \"package\" or \"source\""
+            )
+        if len(kwargs) != 1:
+            raise ConfigError(config_err)
+        desired_install_method = kwargs.keys()[0]
+        state_msg = (
+            "Actual DeepSea install method ->{}<- and desired "
+            "install method ->{}<- "
+            .format(self.install_method, desired_install_method)
+            )
+        if desired_install_method != self.install_method:
+            raise ConfigError(
+                self.err_prefix + state_msg + 
+                "different! This test requires that they be the same."
+                )
+        self.log.info(state_msg + "the same")
+
     def iscsi_smoke_test(self, **kwargs):
         igw_host = self.role_type_present("igw")
         if igw_host:
@@ -1647,6 +1827,7 @@ health_ok = HealthOK
 orch = Orch
 policy = Policy
 reboot = Reboot
+repository = Repository
 script = Script
 state = State
 validation = Validation

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -9,27 +9,22 @@ import yaml
 
 from salt_manager import SaltManager
 from scripts import Scripts
+from teuthology import misc
 from util import (
     copy_directory_recursively,
     get_remote_for_role,
     introspect_roles,
+    remote_exec,
     remote_run_script_as_root,
     sudo_append_to_file,
     )
 
 from teuthology.exceptions import (
     CommandFailedError,
-    ConnectionLostError,
     ConfigError,
-    )
-from teuthology.misc import (
-    sh,
-    sudo_write_file,
-    write_file,
     )
 from teuthology.orchestra import run
 from teuthology.task import Task
-from teuthology.contextutil import safe_while
 
 log = logging.getLogger(__name__)
 deepsea_ctx = {}
@@ -48,45 +43,6 @@ def dump_file_that_might_not_exist(remote, fpath):
         remote.run(args="cat {}".format(fpath))
     except CommandFailedError:
         pass
-
-
-def remote_exec(remote, cmd_str, log_spec, quiet=True, rerun=False, tries=0):
-    """
-    Execute cmd_str and catch CommandFailedError and ConnectionLostError (and
-    rerun cmd_str post-reboot if rerun flag is set) until one of the conditons
-    are fulfilled:
-    1) Execution succeeded
-    2) Attempts are exceeded
-    3) CommandFailedError is raised
-    """
-    cmd_str = "sudo bash -c '{}'".format(cmd_str)
-    # if quiet:
-    #     cmd_args += [run.Raw('2>'), "/dev/null"]
-    already_rebooted_at_least_once = False
-    if tries:
-        remote.run(args="uptime")
-        log.info("Running command ->{}<- on {}. "
-                 "This might cause the machine to reboot!"
-                 .format(cmd_str, remote.hostname))
-    with safe_while(sleep=60, tries=tries, action="wait for reconnect") as proceed:
-        while proceed():
-            try:
-                if already_rebooted_at_least_once:
-                    if not rerun:
-                        remote.run(args="echo Back from reboot ; uptime")
-                        break
-                remote.run(args=cmd_str)
-                break
-            except CommandFailedError:
-                log.error(anchored("{} failed. Here comes journalctl!"
-                                   .format(log_spec)))
-                remote.run(args="sudo journalctl --all")
-                raise
-            except ConnectionLostError:
-                already_rebooted_at_least_once = True
-                if tries < 1:
-                    raise
-                log.warning("No connection established yet..")
 
 
 class DeepSea(Task):
@@ -443,6 +399,7 @@ class DeepSea(Task):
         remote_exec(
             remote,
             cmd_str,
+            self.log,
             log_spec,
             rerun=False,
             quiet=True,
@@ -459,6 +416,7 @@ class DeepSea(Task):
         remote_exec(
             self.master_remote,
             cmd_str,
+            self.log,
             log_spec,
             rerun=False,
             quiet=True,
@@ -790,9 +748,9 @@ class HealthOK(DeepSea):
         global deepsea_ctx
         suite_path = self.ctx.config.get('suite_path')
         log.info("suite_path is ->{}<-".format(suite_path))
-        sh("ls -l {}".format(suite_path))
+        misc.sh("ls -l {}".format(suite_path))
         health_ok_path = suite_path + "/deepsea/health-ok"
-        sh("test -d " + health_ok_path)
+        misc.sh("test -d " + health_ok_path)
         copy_directory_recursively(
                 health_ok_path, self.master_remote, "health-ok")
         self.master_remote.run(args="pwd ; ls -lR health-ok")
@@ -866,7 +824,6 @@ class Orch(DeepSea):
         deepsea_ctx['logger_obj'] = log.getChild('orch')
         self.name = 'deepsea.orch'
         super(Orch, self).__init__(ctx, config)
-        # cast stage/state_orch value to str because it might be a number
         self.stage = str(self.config.get("stage", ''))
         self.state_orch = str(self.config.get("state_orch", ''))
         self.reboots_explicitly_forbidden = not self.config.get("allow_reboots", True)
@@ -1027,6 +984,7 @@ class Orch(DeepSea):
         remote_exec(
             self.master_remote,
             cmd_str,
+            self.log,
             "orchestration {}".format(orch_spec),
             rerun=True,
             quiet=True,
@@ -1217,7 +1175,7 @@ class Policy(DeepSea):
                 "{}/{}".format(proposals_dir, ypp))
 
     def __roll_out_custom_profile(self, fpath="/home/ubuntu/custom_profile"):
-        sudo_write_file(
+        misc.sudo_write_file(
             self.master_remote,
             fpath,
             yaml.dump(self.storage_profile),
@@ -1318,7 +1276,7 @@ class Policy(DeepSea):
         """
         Write policy_cfg to master remote.
         """
-        sudo_write_file(
+        misc.sudo_write_file(
             self.master_remote,
             proposals_dir + "/policy.cfg",
             self.policy_cfg,
@@ -1607,61 +1565,6 @@ class Script(DeepSea):
         pass
 
 
-class State(DeepSea):
-    """
-    Runs an arbitrary Salt State on some minions.
-
-    This subtask understands the following config keys:
-
-        state    name of the state to run (mandatory)
-
-        target   target selection specifier (default: *)
-                 For details, see "man salt"
-    """
-
-    err_prefix = '(state subtask) '
-
-    def __init__(self, ctx, config):
-        deepsea_ctx['logger_obj'] = log.getChild('state')
-        super(State, self).__init__(ctx, config)
-        # cast stage/state_orch value to str because it might be a number
-        self.state = str(self.config.get("state", ''))
-        # targets all machines if omitted
-        self.target = str(self.config.get("target", '*'))
-        if not self.state:
-            raise ConfigError(
-                self.err_prefix + "nothing to do. Specify a non-empty value for 'state'")
-
-    def _run_state(self):
-        """Run a state. Dump journalctl on error."""
-        if '*' in self.target:
-            quoted_target = "\'{}\'".format(self.target)
-        else:
-            quoted_target = self.target
-        cmd_str = (
-            "set -ex\n"
-            "timeout 60m salt {} --no-color state.apply {}\n"
-            ).format(quoted_target, self.state)
-        if self.quiet_salt:
-            cmd_str += ' 2>/dev/null'
-        write_file(self.master_remote, 'run_salt_state.sh', cmd_str)
-        remote_exec(
-            self.master_remote,
-            'sudo bash run_salt_state.sh',
-            "state {}".format(self.state),
-            )
-
-    def begin(self):
-        self.log.info(anchored("running state {}".format(self.state)))
-        self._run_state()
-
-    def end(self):
-        pass
-
-    def teardown(self):
-        pass
-
-
 class Validation(DeepSea):
     """
     A container for "validation tests", which are understood to mean tests that
@@ -1725,7 +1628,7 @@ class Validation(DeepSea):
             )
         if desired_install_method != self.install_method:
             raise ConfigError(
-                self.err_prefix + state_msg + 
+                self.err_prefix + state_msg +
                 "different! This test requires that they be the same."
                 )
         self.log.info(state_msg + "the same")
@@ -1829,5 +1732,4 @@ policy = Policy
 reboot = Reboot
 repository = Repository
 script = Script
-state = State
 validation = Validation

--- a/qa/tasks/scripts.py
+++ b/qa/tasks/scripts.py
@@ -19,8 +19,17 @@ class Scripts:
             ctx['scripts_copied'] = True
 
     def run(self, remote, script_name, args=[], as_root=True):
-        self.log.info('(scripts) running script {} on remote {}'
-                      .format(script_name, remote.hostname)
+        class_name = type(remote).__name__
+        self.log.debug(
+            '(scripts) run method was passed a remote object of class {}'
+            .format(class_name)
+            )
+        if class_name == 'Cluster':
+            remote_spec = 'the whole cluster'
+        else:
+            remote_spec = 'remote {}'.format(remote.hostname)
+        self.log.info('(scripts) running script {} with args {} on {}'
+                      .format(script_name, args, remote_spec)
                       )
         path = 'scripts/' + script_name
         cmd = 'bash {}'.format(path)

--- a/qa/tasks/scripts/clobber_repositories.sh
+++ b/qa/tasks/scripts/clobber_repositories.sh
@@ -1,0 +1,35 @@
+# clobber_repositories.sh
+#
+# args: some repositories in format name:url
+#
+# TODO: priority
+
+set -ex
+
+if [ -d /etc/zypp/repos.d.bck ] ; then
+    echo "Repos were already clobbered. Doing nothing." 2>/dev/null
+    exit 0
+fi
+
+echo "Repos BEFORE clobber" 2>/dev/null
+zypper lr -upEP
+
+cp -a /etc/zypp/repos.d /etc/zypp/repos.d.bck
+rm -f /etc/zypp/repos.d/*
+
+for repo_spec in "$@" ; do
+    repo_name=$(echo $repo_spec | sed -e 's/\:.*$//')
+    repo_url=$(echo $repo_spec | sed -e 's/^.*\:\(http:.*$\)/\1/')
+    zypper \
+        --non-interactive \
+        addrepo \
+        --refresh \
+        --no-gpgcheck \
+        $repo_url \
+        $repo_name
+done
+
+zypper --non-interactive --no-gpg-checks refresh
+
+echo "Repos AFTER clobber" 2>/dev/null
+zypper lr -upEP


### PR DESCRIPTION
TODO:
- [x] figure out how to distinguish between a Cluster object and a Remote object
- [x] `zypper rm` conflicting RPMs on all nodes, not just on master
- [x] enforce deepsea must be installed from RPM
- [x] `--suite deepsea/tier4/upgrade` gets all the way to `ceph.maintenance.upgrade`
