### PR TITLE
qa/deepsea: switch default SLE version from 15.0 to 15.1

### DIFF
--- a/qa/deepsea/distros/sle_15.0.yaml
+++ b/qa/deepsea/distros/sle_15.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/sle_15.0.yaml

--- a/qa/deepsea/distros/sle_15.1.yaml
+++ b/qa/deepsea/distros/sle_15.1.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/sle_15.1.yaml

--- a/qa/distros/all/sle_15.1.yaml
+++ b/qa/distros/all/sle_15.1.yaml
@@ -1,0 +1,2 @@
+os_type: sle
+os_version: "15.1"

--- a/qa/tasks/scripts/salt_api_test.sh
+++ b/qa/tasks/scripts/salt_api_test.sh
@@ -1,6 +1,6 @@
 # salt_api_test.sh
 # Salt API test script
-set -e
+set -ex
 TMPFILE=$(mktemp)
 curl --silent http://$(hostname):8000/ | tee $TMPFILE # show curl output in log
 test -s $TMPFILE


### PR DESCRIPTION
- [x] https://github.com/SUSE/teuthology/pull/180 merged
- [ ] CI tests shown to run stable in SLE-15-SP1 on ECP
