### PR TITLE
qa/tasks/deepsea: set osd_memory_target to 1GiB

### DIFF
--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -557,6 +557,7 @@ class CephConf(DeepSea):
 
     targets = {
         "mon_allow_pool_delete": True,
+        "osd_memory_target": True,
         "small_cluster": True,
         "rbd": False,
         }
@@ -617,6 +618,16 @@ class CephConf(DeepSea):
         sudo_append_to_file(
             self.master_remote,
             self.__ceph_conf_d_full_path("mon"),
+            data,
+            )
+        self.log.info(info_msg)
+
+    def osd_memory_target(self):
+        info_msg = "lowered osd_memory_target to 1GiB to facilitate testing in OpenStack"
+        data = "osd memory target = 1105322466"  # https://tracker.ceph.com/issues/37507#note-4
+        sudo_append_to_file(
+            self.master_remote,
+            self.__ceph_conf_d_full_path("osd"),
             data,
             )
         self.log.info(info_msg)


### PR DESCRIPTION
In SES6 (and SES5 since 12.2.10), Ceph uses a higher default value of
osd_memory_target (4GiB) which might cause OOM in longer-running tests,
especially when we start using OpenStack flavors with 4GiB of RAM instead of
8GiB.

Note: the OSD might not start if the osd_memory_target is set *too* low.
Use the value recommended in https://tracker.ceph.com/issues/37507#note-4

References: https://trello.com/c/X5StTYxZ/378-teuthology-runs-in-ecp-use-needlessly-large-flavor
Related-to: https://github.com/SUSE/teuthology/pull/176
Signed-off-by: Nathan Cutler <ncutler@suse.com>