### PR TITLE
qa/deepsea: increase reboot_tries from 15 to 30

### DIFF
--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -29,7 +29,7 @@ from teuthology.task import Task
 log = logging.getLogger(__name__)
 deepsea_ctx = {}
 proposals_dir = "/srv/pillar/ceph/proposals"
-reboot_tries = 15
+reboot_tries = 30
 
 
 def anchored(log_message):


### PR DESCRIPTION
Occasionally a node does not respond to SSH after reboot.

Signed-off-by: Nathan Cutler <ncutler@suse.com>