### PR TITLE
Use rbd/journal.sh upstream workunit as replacement for bench-write from qa-automation

### DIFF
--- a/qa/suites/deepsea/tier3/rbd/3-test-phase.yaml
+++ b/qa/suites/deepsea/tier3/rbd/3-test-phase.yaml
@@ -7,3 +7,4 @@ tasks:
     clients:
       client.0:
         - rbd/cli_generic.sh
+        - rbd/journal.sh


### PR DESCRIPTION
Teuthology run: 
http://10.86.2.104/ubuntu-2019-01-25_13:02:15-deepsea:tier3-wip-qa-rbd-journal---basic-openstack/6/teuthology.log

PS. `rbd bench-write` is replaced by `rbd bench --io-type write` . Upstream PR will follow up...