### PR TITLE
rgw: Fix for SignatureMismatchError in s3 commands.

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -722,7 +722,7 @@ sha256_digest_t calc_hash_sha256(const boost::string_view& msg)
   sha256_digest_t hash;
 
   SHA256 hasher;
-  hasher.Update(reinterpret_cast<const unsigned char*>(hash.v), msg.size());
+  hasher.Update(reinterpret_cast<const unsigned char*>(msg.data()), msg.size());
   hasher.Final(hash.v);
 
   return hash;


### PR DESCRIPTION
Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>