### PR TITLE
rgw_file: use correct secret key to check auth

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -645,11 +645,15 @@ struct RGWUserInfo
       type(TYPE_NONE) {
   }
 
-  RGWAccessKey* get_key0() {
+  RGWAccessKey* get_key(const string& access_key) {
     if (access_keys.empty())
       return nullptr;
+
+    auto k = access_keys.find(access_key);
+    if (k == access_keys.end())
+      return nullptr;
     else
-      return &(access_keys.begin()->second);
+      return &(k->second);
   }
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -918,9 +918,8 @@ namespace rgw {
     int authorize(RGWRados* store) {
       int ret = rgw_get_user_info_by_access_key(store, key.id, user);
       if (ret == 0) {
-	RGWAccessKey* key0 = user.get_key0();
-	if (!key0 ||
-	    (key0->key != key.key))
+	RGWAccessKey* k = user.get_key(key.id);
+	if (!k || (k->key != key.key))
 	  return -EINVAL;
 	if (user.suspended)
 	  return -ERR_USER_SUSPENDED;


### PR DESCRIPTION
Currently, the authorize function in rgw_file only use the secret key of
first key pair to compare, add a function which get secret key by user's
access key and check the result is match with user's secret key.

Fixes: https://tracker.ceph.com/issues/37855

Signed-off-by: MinSheng Lin <minsheng.l@inwinstack.com>
(cherry picked from commit e92755c60325475342afcafcd5293a20e3e5216a)