### PR TITLE
[DOWNSTREAM] rpm: drop Recommends: ceph-mgr-ssh

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -451,7 +451,6 @@ Recommends:	ceph-mgr-dashboard = %{_epoch_prefix}%{version}-%{release}
 Recommends:	ceph-mgr-diskprediction-local = %{_epoch_prefix}%{version}-%{release}
 Recommends:	ceph-mgr-diskprediction-cloud = %{_epoch_prefix}%{version}-%{release}
 Recommends:	ceph-mgr-rook = %{_epoch_prefix}%{version}-%{release}
-Recommends:	ceph-mgr-ssh = %{_epoch_prefix}%{version}-%{release}
 %endif
 %if 0%{?rhel} == 7
 Requires:       pyOpenSSL


### PR DESCRIPTION
Downstream-only commit. This package is not supported or shipped in SES6.

References: https://jira.suse.de/browse/SES-176
Signed-off-by: Nathan Cutler <ncutler@suse.com>