### PR TITLE
cmake: empty INSTALL_RPATH for libceph_crypto_openssl.so

### DIFF
--- a/src/crypto/openssl/CMakeLists.txt
+++ b/src/crypto/openssl/CMakeLists.txt
@@ -7,4 +7,5 @@ set(openssl_crypto_plugin_srcs
 add_library(ceph_crypto_openssl SHARED ${openssl_crypto_plugin_srcs})
 target_link_libraries(ceph_crypto_openssl PRIVATE crypto)
 add_dependencies(crypto_plugins ceph_crypto_openssl)
+set_target_properties(ceph_crypto_openssl PROPERTIES INSTALL_RPATH "")
 install(TARGETS ceph_crypto_openssl DESTINATION ${crypto_plugin_dir})


### PR DESCRIPTION
See 235448879e5 for explanation.

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1129921
Signed-off-by: Nathan Cutler <ncutler@suse.com>