### PR TITLE
rpm: have pybind RPMs provide/obsolete their python2 predecessors

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -745,6 +745,8 @@ Group:		Development/Libraries/Python
 Requires:	python%{python3_pkgversion}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Provides:	python3-rados = %{_epoch_prefix}%{version}-%{release}
+Provides:	python-rados = %{_epoch_prefix}%{version}-%{release}
+Obsoletes:      python-rados < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rados
 This package contains Python 3 libraries for interacting with Cephs RADOS
 object store.
@@ -832,6 +834,8 @@ Group:		Development/Libraries/Python
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
 Provides:	python3-rbd = %{_epoch_prefix}%{version}-%{release}
+Provides:	python-rbd = %{_epoch_prefix}%{version}-%{release}
+Obsoletes:	python-rbd < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rbd
 This package contains Python 3 libraries for interacting with Cephs RADOS
 block device.
@@ -890,6 +894,8 @@ Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 Provides:	python3-cephfs = %{_epoch_prefix}%{version}-%{release}
+Provides:	python-cephfs = %{_epoch_prefix}%{version}-%{release}
+Obsoletes:	python-cephfs < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-cephfs
 This package contains Python 3 libraries for interacting with Cephs distributed
 file system.


### PR DESCRIPTION
This is a downstream-only commit - the changes were made based on my reading of https://en.opensuse.org/openSUSE:Upgrade_dependencies_explanation

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1125899
Signed-off-by: Nathan Cutler <ncutler@suse.com>