### PR TITLE
[SES5] rpm: add downstream-only ceph-qa-health-ok subpackage

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -792,6 +792,14 @@ python-rados, python-rbd, python-rgw and python-cephfs. Packages still
 depending on python-ceph should be fixed to depend on python-rados,
 python-rbd, python-rgw or python-cephfs instead.
 
+%if 0%{?suse_version}
+%package qa-health-ok
+Summary:        DeepSea integration test automation scripts
+Group:          System/Libraries
+%description qa-health-ok
+This package contains health-ok.sh and associated test automation scripts.
+%endif
+
 #################################################################################
 # common
 #################################################################################
@@ -970,6 +978,10 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
 %py3_compile %{buildroot}%{python3_sitelib}
+# ceph-qa-health-ok
+install -d -m 755 %{buildroot}%{_libexecdir}/deepsea/qa/common
+install -m 755 qa/deepsea/health-ok/*.sh %{buildroot}%{_libexecdir}/deepsea/qa/
+install -m 644 qa/deepsea/health-ok/common/*.sh %{buildroot}%{_libexecdir}/deepsea/qa/common/
 %endif
 
 %clean
@@ -1817,6 +1829,10 @@ exit 0
 # We need an empty %%files list for python-ceph-compat, to tell rpmbuild to
 # actually build this meta package.
 
+%if 0%{?suse_version}
+%files qa-health-ok
+%{_libexecdir}/deepsea
+%endif
 
 %changelog
 # nospeccleaner

--- a/qa/deepsea/health-ok/common/common.sh
+++ b/qa/deepsea/health-ok/common/common.sh
@@ -68,24 +68,14 @@ function run_stage_2 {
     test "$STAGE_SUCCEEDED"
 }
 
-function _disable_tuned {
-    local prefix=/srv/salt/ceph/tuned
-    mv $prefix/mgr/default.sls $prefix/mgr/default.sls-MOVED
-    mv $prefix/mon/default.sls $prefix/mon/default.sls-MOVED
-    mv $prefix/osd/default.sls $prefix/osd/default.sls-MOVED
-    mv $prefix/mgr/default-off.sls $prefix/mgr/default.sls
-    mv $prefix/mon/default-off.sls $prefix/mon/default.sls
-    mv $prefix/osd/default-off.sls $prefix/osd/default.sls
-}
-
 function run_stage_3 {
     cat_global_conf
     lsblk_on_storage_node
     if [ "$TUNED" ] ; then
         echo "WWWW: tuned will be deployed as usual"
     else
-        echo "WWWW: tuned will NOT be deployed"
-        _disable_tuned
+        echo "WWWW: tuned was not to have been deployed, but disabling it is a WIP"
+        # _disable_tuned
     fi
     _run_stage 3 "$@"
     lsblk_on_storage_node
@@ -154,13 +144,6 @@ function ceph_conf_mon_allow_pool_delete {
     echo "Adjusting ceph.conf to allow pool deletes"
     cat <<'EOF' >> /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf
 mon allow pool delete = true
-EOF
-}
-
-function ceph_conf_dashboard {
-    echo "Adjusting ceph.conf for deployment of dashboard MGR module"
-    cat <<'EOF' >> /srv/salt/ceph/configuration/files/ceph.conf.d/mon.conf
-mgr initial modules = dashboard
 EOF
 }
 

--- a/qa/deepsea/health-ok/common/deploy.sh
+++ b/qa/deepsea/health-ok/common/deploy.sh
@@ -198,7 +198,6 @@ function deploy_ceph {
         run_stage_2 "$CLI"
         ceph_conf_small_cluster
         ceph_conf_mon_allow_pool_delete
-        ceph_conf_dashboard
         test "$RBD" && ceph_conf_upstream_rbd_default_features
     fi
     if [ "$START_STAGE" -le "3" ] ; then
@@ -206,7 +205,7 @@ function deploy_ceph {
         pre_create_pools
         ceph_cluster_status
         test "$RBD" && ceph_test_librbd_can_be_run
-        if [ -z "$MDS" -a -z "$NFS_GANESHA" -a -z "$RGW" ] ; then
+        if [ -z "$MDS" -a -z "$NFS_GANESHA" -a -z "$RGW" -a -z "$IGW" -a -z "$OPENATTIC" ] ; then
             echo "WWWW"
             echo "Stage 3 OK, no roles requiring Stage 4: $DEPLOY_PHASE_COMPLETE_MESSAGE"
             return 0

--- a/qa/deepsea/health-ok/common/helper.sh
+++ b/qa/deepsea/health-ok/common/helper.sh
@@ -37,6 +37,7 @@ function _run_stage_cli {
     local deepsea_cli_output_path="/tmp/deepsea.${stage_num}.log"
 
     set +e
+    echo "DEV_ENV ->$DEV_ENV<-"
     set -x
     timeout $STAGE_TIMEOUT_DURATION \
         deepsea \
@@ -69,6 +70,7 @@ function _run_stage_non_cli {
     local stage_log_path="/tmp/stage.${stage_num}.log"
 
     set +e
+    echo "DEV_ENV ->$DEV_ENV<-"
     set -x
     timeout $STAGE_TIMEOUT_DURATION \
         salt-run \

--- a/qa/deepsea/health-ok/health-openattic.sh
+++ b/qa/deepsea/health-ok/health-openattic.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# wrapper around health-ok.sh for deploying a Ceph cluster with openATTIC
+#
+set -e
+set +x
+
+SCRIPTNAME=$(basename ${0})
+BASEDIR=$(readlink -f "$(dirname ${0})")
+test -d $BASEDIR
+
+source $BASEDIR/health-ok.sh --client-nodes=1 --mds --igw --min-nodes=2 --nfs-ganesha --openattic --rgw

--- a/qa/deepsea/health-ok/stage-5.sh
+++ b/qa/deepsea/health-ok/stage-5.sh
@@ -28,7 +28,6 @@ set +x
 SCRIPTNAME=$(basename ${0})
 BASEDIR=$(readlink -f "$(dirname ${0})")
 test -d $BASEDIR
-[[ $BASEDIR =~ \/health-ok$ ]]
 
 source $BASEDIR/common/common.sh
 


### PR DESCRIPTION
This commit adds a "ceph-qa-health-ok" subpackage to ceph.spec.in so we can continue running "health-openattic.sh" to deploy a ceph cluster for openATTIC CI testing purposes even now that https://github.com/SUSE/DeepSea/pull/1566 has been merged.