### PR TITLE
rgw: fix default_placement containing "/" when storage_class is standard

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -695,7 +695,7 @@ struct rgw_placement_rule {
 
   void encode(bufferlist& bl) const {
     /* no ENCODE_START/END due to backward compatibility */
-    std::string s = to_str_explicit();
+    std::string s = to_str();
     ceph::encode(s, bl);
   }
 
@@ -720,12 +720,11 @@ struct rgw_placement_rule {
     size_t pos = s.find("/");
     if (pos == std::string::npos) {
       name = s;
+      storage_class.clear();
       return;
     }
     name = s.substr(0, pos);
-    if (pos < s.size() - 1) {
-      storage_class = s.substr(pos + 1);
-    }
+    storage_class = s.substr(pos + 1);
   }
 
   bool standard_storage_class() const {


### PR DESCRIPTION
fixes: http://tracker.ceph.com/issues/39380

