### PR TITLE
qa/deepsea: redirect journalctl output to a logfile

### DIFF
--- a/qa/tasks/salt.py
+++ b/qa/tasks/salt.py
@@ -223,6 +223,7 @@ class Salt(Task):
         self.sm.gather_logs('salt')
         self.sm.gather_logs('zypp')
         self.sm.gather_logfile('zypper.log')
+        self.sm.gather_logfile('journalctl.log')
         log.debug("end of end method")
 
     def teardown(self):

--- a/qa/tasks/util/__init__.py
+++ b/qa/tasks/util/__init__.py
@@ -216,8 +216,9 @@ def remote_exec(remote, cmd_str, logger, log_spec, quiet=True, rerun=False, trie
                 remote.run(args=cmd_str)
                 break
             except CommandFailedError:
-                logger.error("{} failed. Here comes journalctl!".format(log_spec))
-                remote.run(args="sudo journalctl --all")
+                logger.error(("{} failed. Creating /var/log/journalctl.log with "
+                              "output of \"journalctl --all\"!").format(log_spec))
+                remote.sh("sudo journalctl --all > /var/log/journalctl.log")
                 raise
             except ConnectionLostError:
                 already_rebooted_at_least_once = True


### PR DESCRIPTION
Putting it on stdout makes the teuthology.log file unnecessarily large.

Signed-off-by: Nathan Cutler <ncutler@suse.com>