### PR TITLE
qa/deepsea: use ceph_cm_ansible: false instead of ceph_cm: salt

### DIFF
--- a/qa/deepsea/boilerplate/ceph_cm_salt.yaml
+++ b/qa/deepsea/boilerplate/ceph_cm_salt.yaml
@@ -1,1 +1,2 @@
 ceph_cm: salt
+ceph_cm_ansible: false


### PR DESCRIPTION
Signed-off-by: Nathan Cutler <ncutler@suse.com>