### PR TITLE
common: make ms_bind_msgr2 default to "false"

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -981,7 +981,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("ms_bind_msgr2"),
 
     Option("ms_bind_msgr2", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description("Bind servers to msgr2 (nautilus+) protocol address(es)")
     .add_see_also("ms_bind_msgr1"),
 


### PR DESCRIPTION
If Ceph is not patched to suppress this warning, customers performing the
upgrade manually will unavoidably get HEALTH_WARN when the Nautilus MON
cluster forms. Then they can either manually issue a command to suppress it
or, alternatively, tolerate HEALTH_WARN status until DeepSea Stage 3 is run
later in the procedure.

This cognitive dissonance can be eliminated by this simple patch. The disadvantage
of diverging from upstream is outweighed by the usability benefit.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1124957
Signed-off-by: Nathan Cutler <ncutler@suse.com>