### PR TITLE
rpm: make python3-rgw replace python-rgw on upgrade

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -722,6 +722,8 @@ Group:		Development/Libraries/Python
 Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
 Provides: 	python3-rgw = %{_epoch_prefix}%{version}-%{release}
+Provides:	python-rgw = %{_epoch_prefix}%{version}-%{release}
+Obsoletes:	python-rgw < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rgw
 This package contains Python 3 libraries for interacting with Cephs RADOS
 gateway.


### PR DESCRIPTION
Follow-up commit to https://github.com/SUSE/ceph/commit/efb8dfad8f0