### PR TITLE
qa:tasks:util: fix log write permission error

### DIFF
--- a/qa/tasks/util/__init__.py
+++ b/qa/tasks/util/__init__.py
@@ -234,7 +234,7 @@ def remote_exec(remote, cmd_str, logger, log_spec, quiet=True, rerun=False, trie
             except CommandFailedError:
                 logger.error(("{} failed. Creating /var/log/journalctl.log with "
                               "output of \"journalctl --all\"!").format(log_spec))
-                remote.sh("sudo journalctl --all > /var/log/journalctl.log")
+                remote.sh("sudo su -c 'journalctl --all > /var/log/journalctl.log'")
                 raise
             except ConnectionLostError:
                 already_rebooted_at_least_once = True


### PR DESCRIPTION
[skip ci] Should prevent cases like:
```
sudo journalctl --all > /var/log/journalctl.log
/var/log/journalctl.log: Permission denied
```

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>