### PR TITLE
rgw: Move upload_info declaration out of conditional

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3645,10 +3645,10 @@ void RGWPutObj::execute()
 
   rgw_placement_rule *pdest_placement;
 
+  multipart_upload_info upload_info;
   if (multipart) {
     RGWMPObj mp(s->object.name, multipart_upload_id);
 
-    multipart_upload_info upload_info;
     op_ret = get_multipart_info(store, s, mp.get_meta(), nullptr, nullptr, &upload_info);
     if (op_ret < 0) {
       if (op_ret != -ENOENT) {


### PR DESCRIPTION
bsc#1137189

Upstream counterpart https://github.com/ceph/ceph/pull/29898 is still open.

To be submitted as a pre-14.2.3 maintenance update.