### PR TITLE
[SES5] [backport] qa:tasks:util: fix log write permission error

### DIFF
--- a/qa/tasks/util/__init__.py
+++ b/qa/tasks/util/__init__.py
@@ -216,8 +216,9 @@ def remote_exec(remote, cmd_str, logger, log_spec, quiet=True, rerun=False, trie
                 remote.run(args=cmd_str)
                 break
             except CommandFailedError:
-                logger.error("{} failed. Here comes journalctl!".format(log_spec))
-                remote.run(args="sudo journalctl --all")
+                logger.error(("{} failed. Creating /var/log/journalctl.log with "
+                              "output of \"journalctl --all\"!").format(log_spec))
+                remote.sh("sudo su -c 'journalctl --all > /var/log/journalctl.log'")
                 raise
             except ConnectionLostError:
                 already_rebooted_at_least_once = True


### PR DESCRIPTION
[skip ci] Should prevent cases like:
```
sudo journalctl --all > /var/log/journalctl.log
/var/log/journalctl.log: Permission denied
```

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>
(cherry picked from commit 86773345c4c1064ad390684c81261116cdb3be36)