### PR TITLE
iscsi_smoke_test: restart iscsid service

### DIFF
--- a/qa/tasks/scripts/iscsi_smoke_test.sh
+++ b/qa/tasks/scripts/iscsi_smoke_test.sh
@@ -53,7 +53,9 @@ zypper --non-interactive --no-gpg-checks install \
 
 sed -i -e 's/InitiatorName=.\+/InitiatorName=iqn.1994-05.com.redhat:rh7-client/g' /etc/iscsi/initiatorname.iscsi
 
-systemctl start iscsid.service
+systemctl status iscsid.service || true
+systemctl restart iscsid.service
+
 sleep 5
 systemctl --no-pager --full status iscsid.service
 


### PR DESCRIPTION
Doing "systemctl start iscsid" after modifying config files
might not be enough, because the service can be loaded and
running already we need to do a "restart"

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>