### PR TITLE
qa/deepsea: do not fail the test if ganesha.report not present

### DIFF
--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -1877,14 +1877,14 @@ class Validation(DeepSea):
             raise ConfigError(self.err_prefix +
                               "ganesha_smoke_test needs an rgw or mds role, but neither was given")
         if client_host:
-            self.master_remote.sh("sudo salt-run ganesha.report 2>/dev/null")
+            self.master_remote.sh("sudo salt-run ganesha.report 2>/dev/null || true")
             remote = self.remotes[client_host]
             self.scripts.run(
                 remote,
                 'ganesha_smoke_test.sh',
                 args=args,
                 )
-            self.master_remote.sh("sudo salt-run ganesha.report 2>/dev/null")
+            self.master_remote.sh("sudo salt-run ganesha.report 2>/dev/null || true")
         else:
             raise ConfigError(self.err_prefix +
                               "ganesha_smoke_test needs a client role, but none was given")


### PR DESCRIPTION
In order to ease the roll-out of ganesha.report to the various CIs.

Signed-off-by: Nathan Cutler <ncutler@suse.com>