### PR TITLE
[SES5] qa/deepsea: never use DeepSea CLI to run orchestrations

### DIFF
--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -1014,8 +1014,10 @@ class Orch(DeepSea):
         global reboot_tries
         orch_type, orch_spec = orch_tuple
         if orch_type == 'orch':
+            cli = False
             pass
         elif orch_type == 'stage':
+            cli = self.deepsea_cli
             orch_spec = 'ceph.stage.{}'.format(orch_spec)
         else:
             raise ConfigError(
@@ -1023,7 +1025,7 @@ class Orch(DeepSea):
                 "Unrecognized orchestration type ->{}<-".format(orch_type)
                 )
         cmd_str = None
-        if self.deepsea_cli:
+        if cli:
             cmd_str = (
                 'timeout 60m deepsea '
                 '--log-file=/var/log/salt/deepsea.log '


### PR DESCRIPTION
The CLI cannot handle all possible Salt/Jinja syntax, and running anything
other than the DeepSea Stages is out of scope for it.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 99971515fd15710d5a28ff5a92984d918aba79cd)