### PR TITLE
[SES5] [backport] qa/tasks: py3 compatibility

### DIFF
--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -418,7 +418,7 @@ class DeepSea(Task):
     def _purge_osds(self):
         # needed as long as teuthology install task purges /var/lib/ceph
         # in its teardown phase
-        for _remote in self.ctx.cluster.remotes.iterkeys():
+        for _remote in self.ctx.cluster.remotes.keys():
             self.log.info("stopping OSD services on {}"
                           .format(_remote.hostname))
             _remote.run(args=[
@@ -621,7 +621,7 @@ class CephConf(DeepSea):
             return "{}/{}".format(ceph_conf_d, self.customize[section])
 
     def __custom_ceph_conf(self, section, customizations):
-        for conf_item, conf_value in customizations.iteritems():
+        for conf_item, conf_value in customizations.items():
             data = '{} = {}\n'.format(conf_item, conf_value)
             sudo_append_to_file(
                 self.master_remote,
@@ -1738,7 +1738,7 @@ class Validation(DeepSea):
 
     def begin(self):
         self.log.debug("Processing tests: ->{}<-".format(self.config.keys()))
-        for method_spec, kwargs in self.config.iteritems():
+        for method_spec, kwargs in self.config.items():
             kwargs = {} if not kwargs else kwargs
             if not isinstance(kwargs, dict):
                 raise ConfigError(self.err_prefix + "Method config must be a dict")

--- a/qa/tasks/salt.py
+++ b/qa/tasks/salt.py
@@ -61,7 +61,7 @@ class Salt(Task):
             'sudo', 'sh', '-c',
             'echo discovery: false >> /etc/salt/master'
         ])
-        for rem in self.remotes.iterkeys():
+        for rem in self.remotes.keys():
             rem.run(args=[
                 'sudo', 'sh', '-c',
                 'echo discovery: false >> /etc/salt/minion'
@@ -72,7 +72,7 @@ class Salt(Task):
         Generate minion key on salt master to be used to preseed this cluster's
         minions.
         '''
-        for rem in self.remotes.iterkeys():
+        for rem in self.remotes.keys():
             minion_id = rem.hostname
             log.info('Ensuring that minion ID {} has a keypair on the master'
                      .format(minion_id))
@@ -106,7 +106,7 @@ class Salt(Task):
         Preseed minions with generated and accepted keys; set minion id
         to the remote's hostname.
         '''
-        for rem in self.remotes.iterkeys():
+        for rem in self.remotes.keys():
             minion_id = rem.hostname
             src = 'salt/minion-keys/{}.pub'.format(minion_id)
             dest = '/etc/salt/pki/master/minions/{}'.format(minion_id)
@@ -166,7 +166,7 @@ class Salt(Task):
     def _set_minion_master(self):
         """Points all minions to the master"""
         master_id = self.sm.master_remote.hostname
-        for rem in self.remotes.iterkeys():
+        for rem in self.remotes.keys():
             # remove old master public key if present. Minion will refuse to
             # start if master name changed but old key is present
             delete_file(rem, '/etc/salt/pki/minion/minion_master.pub',
@@ -184,7 +184,7 @@ class Salt(Task):
 
     def _set_debug_log_level(self):
         """Sets log_level: debug for all salt daemons"""
-        for rem in self.remotes.iterkeys():
+        for rem in self.remotes.keys():
             rem.run(args=[
                 'sudo',
                 'sed', '--in-place', '--regexp-extended',

--- a/qa/tasks/salt_manager.py
+++ b/qa/tasks/salt_manager.py
@@ -137,7 +137,7 @@ class SaltManager(object):
     def check_salt_daemons(self):
         self.master_remote.run(args=['sudo', 'salt-key', '-L'])
         systemctl_remote(self.master_remote, 'status', 'salt-master')
-        for _remote in self.ctx.cluster.remotes.iterkeys():
+        for _remote in self.ctx.cluster.remotes.keys():
             systemctl_remote(_remote, 'status', 'salt-minion')
             _remote.run(args='sudo cat /etc/salt/minion_id')
             _remote.run(args='sudo cat /etc/salt/minion.d/master.conf')
@@ -151,7 +151,7 @@ class SaltManager(object):
         systemctl_remote(self.ctx.cluster, "enable", "salt-minion")
 
     def gather_logfile(self, logfile):
-        for _remote in self.ctx.cluster.remotes.iterkeys():
+        for _remote in self.ctx.cluster.remotes.keys():
             try:
                 _remote.run(args=[
                     'sudo', 'test', '-f', '/var/log/{}'.format(logfile),
@@ -170,7 +170,7 @@ class SaltManager(object):
                 ])
 
     def gather_logs(self, logdir):
-        for _remote in self.ctx.cluster.remotes.iterkeys():
+        for _remote in self.ctx.cluster.remotes.keys():
             try:
                 _remote.run(args=[
                     'sudo', 'test', '-d', '/var/log/{}/'.format(logdir),

--- a/qa/tasks/ses_qa.py
+++ b/qa/tasks/ses_qa.py
@@ -82,7 +82,7 @@ class Validation(SESQA):
 
     def begin(self):
         self.log.debug("Processing tests: ->{}<-".format(self.config.keys()))
-        for method_spec, kwargs in self.config.iteritems():
+        for method_spec, kwargs in self.config.items():
             kwargs = {} if not kwargs else kwargs
             if not isinstance(kwargs, dict):
                 raise ConfigError(self.err_prefix + "Method config must be a dict")


### PR DESCRIPTION
Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>
(cherry picked from commit 29f036121e24bf5b8043709c0e0d64b2a8e4bbde)

 Conflicts:
	qa/tasks/salt_manager.py

`gather_logs` was extended meanwhile...