### PR TITLE
test/osd/safe-to-destroy.sh: explicitly set v1 protocol in --mon-host setting

### DIFF
--- a/src/test/osd/safe-to-destroy.sh
+++ b/src/test/osd/safe-to-destroy.sh
@@ -8,7 +8,7 @@ function run() {
     local dir=$1
     shift
 
-    export CEPH_MON="127.0.0.1:$(get_unused_port)"
+    export CEPH_MON="v1:127.0.0.1:$(get_unused_port)"
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "


### PR DESCRIPTION
Fixes: bsc#1140879

Signed-off-by: Ricardo Dias <rdias@suse.com>