### PR TITLE
qa/health-ok: move ganesha debug log to test phase

### DIFF
--- a/qa/deepsea/health-ok/common/deploy.sh
+++ b/qa/deepsea/health-ok/common/deploy.sh
@@ -214,12 +214,6 @@ function deploy_ceph {
     fi
     if [ "$START_STAGE" -le "4" ] ; then
         run_stage_4 "$CLI"
-        if [ -n "$NFS_GANESHA" ] ; then
-            nfs_ganesha_cat_config_file
-            nfs_ganesha_debug_log
-            echo "WWWW"
-            echo "NFS-Ganesha set to debug logging"
-        fi
         ceph_cluster_status
         _zypper_ps
         echo "Stage 4 OK: $DEPLOY_PHASE_COMPLETE_MESSAGE"

--- a/qa/deepsea/health-ok/health-ok.sh
+++ b/qa/deepsea/health-ok/health-ok.sh
@@ -180,6 +180,10 @@ if [ -n "$RGW" ] ; then
 fi
 test -n "$MDS" -a "$CLIENT_NODES" -ge 1 && cephfs_mount_and_sanity_test
 if [ "$NFS_GANESHA" ] ; then
+    nfs_ganesha_cat_config_file
+    nfs_ganesha_debug_log
+    echo "WWWW"
+    echo "NFS-Ganesha set to debug logging"
     for v in "" "3" "4" ; do
         echo "Testing NFS-Ganesha with NFS version ->$v<-"
         if [ "$RGW" -a "$v" = "3" ] ; then


### PR DESCRIPTION
We don't use the deploy phase anymore, so nfs_ganesha_debug_log was not
getting triggered.

Signed-off-by: Nathan Cutler <ncutler@suse.com>