### PR TITLE
qa/health-ok: disable param substitution in here doc

### DIFF
--- a/qa/deepsea/health-ok/common/nfs-ganesha.sh
+++ b/qa/deepsea/health-ok/common/nfs-ganesha.sh
@@ -23,7 +23,7 @@ EOF
 function nfs_ganesha_debug_log {
   local GANESHANODE=$(_nfs_ganesha_node)
   local TESTSCRIPT=/tmp/test-nfs-ganesha.sh
-  cat <<EOF > $TESTSCRIPT
+  cat <<'EOF' > $TESTSCRIPT
 set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "nfs-ganesha debug log script running as $(whoami) on $(hostname --fqdn)"


### PR DESCRIPTION
Addresses the error:

    + ETC_SYSCONFIG=/etc/sysconfig/ganesha
    + sed -i s/NIV_EVENT/NIV_FULL_DEBUG/g
    sed: no input files

Signed-off-by: Nathan Cutler <ncutler@suse.com>