### PR TITLE
qa/deepsea: Switching distros to 15.2

### DIFF
--- a/qa/deepsea/distros/opensuse_15.1.yaml
+++ b/qa/deepsea/distros/opensuse_15.1.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/opensuse_15.1.yaml

--- a/qa/deepsea/distros/opensuse_15.2.yaml
+++ b/qa/deepsea/distros/opensuse_15.2.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/opensuse_15.2.yaml

--- a/qa/deepsea/distros/sle_15.1.yaml
+++ b/qa/deepsea/distros/sle_15.1.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/sle_15.1.yaml

--- a/qa/deepsea/distros/sle_15.2.yaml
+++ b/qa/deepsea/distros/sle_15.2.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/sle_15.2.yaml


### PR DESCRIPTION
Switching to sle15.2 and leap15.2 that are the supported OS for
SES7 now the the images are available.

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>