### PR TITLE
install-deps.sh: force install python3-devel and python3-base

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -245,6 +245,8 @@ else
     opensuse*|suse|sles)
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
+        # force python3-base and python3-devel to the same version number
+        $SUDO $zypp_install '--force' python3-base python3-devel
         $SUDO $zypp_install systemd-rpm-macros
         munge_ceph_spec_in $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1


### PR DESCRIPTION
This ensures that "python3-devel" and "python3-base" will have the exact
same version number, avoiding failures like:

01:22:57   Could NOT find Python3Libs: Found unsuitable version "3.4.10", but required
01:22:57   is exact version "3.4.6" (found /usr/lib64/libpython3.4m.so)

Signed-off-by: Nathan Cutler <ncutler@suse.com>