### PR TITLE
Add support for ceph network configuration via deepsea

### DIFF
--- a/qa/deepsea/boilerplate/disable-subvolume-check.yaml
+++ b/qa/deepsea/boilerplate/disable-subvolume-check.yaml
@@ -1,0 +1,4 @@
+overrides:
+        deepsea:
+                alternative_defaults:
+                        subvolume_init: disabled

--- a/qa/deepsea/health-ok/common/common.sh
+++ b/qa/deepsea/health-ok/common/common.sh
@@ -301,7 +301,7 @@ function cephfs_mount_and_sanity_test {
 set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "cephfs mount test script running as $(whoami) on $(hostname --fqdn)"
-TESTMONS=$(ceph-conf --lookup 'mon_initial_members' | tr -d '[:space:]')
+TESTMONS=$(ceph-conf --name mon.0  -c /etc/ceph/ceph.conf 'mon_host' |   tr -d '[:space:]')
 TESTSECR=$(grep 'key =' /etc/ceph/ceph.client.admin.keyring | awk '{print $NF}')
 echo "MONs: $TESTMONS"
 echo "admin secret: $TESTSECR"


### PR DESCRIPTION
Fix introduce support for 2 new deepsea task options:
cluster_network: defines ceph cluster network
public_network: defines ceph public network
In both cases network configuration written to '/srv/pillar/ceph/stack/ceph/cluster.yml'

Signed-off-by: Roman Grigorev <rgrigorev@suse.de>