### PR TITLE
qa/suites/deepsea/tier4/upgrade: Switching to upgrade.status + 2 fixes

### DIFF
--- a/qa/suites/deepsea/tier4/upgrade/1-deploy-phase.yaml
+++ b/qa/suites/deepsea/tier4/upgrade/1-deploy-phase.yaml
@@ -11,5 +11,6 @@ tasks:
         - deepsea.ceph_conf:
                 global:
                         bluestore warn on legacy statfs: false
+                        mon_warn_on_pool_pg_num_not_power_of_two: false
         - deepsea.orch:
                 stage: 3

--- a/qa/suites/deepsea/tier4/upgrade/3-test-phase.yaml
+++ b/qa/suites/deepsea/tier4/upgrade/3-test-phase.yaml
@@ -19,7 +19,8 @@ tasks:
         client.salt_master:
                 - 'deepsea --version || true'
                 - 'salt-run deepsea.version 2>/dev/null || true'
-                - 'salt-run status.report 2>/dev/null'
+                - 'salt-run upgrade.status 2>/dev/null'
+                - 'zypper --non-interactive --no-gpg-checks install --force --no-recommends deepsea-cli'
 - print: "Upgrading first cluster node (MON+MGR+OSD) from SES5 to SES6"
 - exec:
         osd.0:
@@ -48,7 +49,7 @@ tasks:
                 osd.0:
 - exec:
         client.salt_master:
-                - 'salt-run status.report 2>/dev/null'
+                - 'salt-run upgrade.status 2>/dev/null'
 - deepsea.toolbox:
         wait_for_health_ok:
 - print: "Upgrading second cluster node (OSD-only) from SES5 to SES6"
@@ -75,7 +76,7 @@ tasks:
                 osd.1:
 - exec:
         client.salt_master:
-                - 'salt-run status.report 2>/dev/null'
+                - 'salt-run upgrade.status 2>/dev/null'
                 - "echo 'All nodes should now be running nautilus'"
 - deepsea.toolbox:
         wait_for_health_ok:


### PR DESCRIPTION
Switching to `upgrade.status` instead of `status.report` as it shows more
clear information and it's in accordance with docs and provide 2 minor fixes for the test

- Installing deepsea-cli on the master node in order to fix CI failure due to failure of deepsea commands after upgrade.

- SIlencing health-warning status for `pool(s) have non-power-of-two pg_num` since it's not a requirement on luminous so it's expected behaviour that's currently causing the test to fail

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>