### PR TITLE
qa/tasks/ceph_salt.py: Fix ceph-salt registries

### DIFF
--- a/qa/tasks/ceph_salt.py
+++ b/qa/tasks/ceph_salt.py
@@ -274,7 +274,8 @@ class CephSalt(Task):
         self.master_remote.sh("sudo ceph-salt config "
                               "/system_update/reboot disable")
         self.master_remote.sh("sudo ceph-salt config /ssh/ generate")
-        self.master_remote.sh("sudo ceph-salt config /containers/registries "
+        self.master_remote.sh("sudo ceph-salt config /containers/"
+                              "registries_conf/registries "
                               "add  prefix={name}"
                               " location={loc} insecure={insec}"
                               .format(name=ceph_salt_ctx['registry_name'],


### PR DESCRIPTION
Fixing the path for adding the registry on ceph-salt that was introduced
by MR #262
(https://github.com/ceph/ceph-salt/commit/407853ad5367d79c4378e19e29b31d13f938f306)

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
