### PR TITLE
SES6: qa: Fix ses_disk_fault_injection, ses_rgw_zones, ses_removing_osd tests

### DIFF
--- a/qa/suites/deepsea/build-validation/ses_rgw_zones/cluster/1disk.yaml
+++ b/qa/suites/deepsea/build-validation/ses_rgw_zones/cluster/1disk.yaml
@@ -1,1 +1,0 @@
-.qa/deepsea/disks/1disk.yaml

--- a/qa/suites/deepsea/build-validation/ses_rgw_zones/cluster/2disks.yaml
+++ b/qa/suites/deepsea/build-validation/ses_rgw_zones/cluster/2disks.yaml
@@ -1,0 +1,1 @@
+.qa/deepsea/disks/2disks.yaml

--- a/qa/tasks/scripts/ses_replace_disk_part1.sh
+++ b/qa/tasks/scripts/ses_replace_disk_part1.sh
@@ -4,7 +4,7 @@ declare -a minion_fqdn="$1"
 
 echo "### Getting random minion and its random OSD ###"
 minion=${minion_fqdn%%.*}
-random_osd=$(ceph osd tree | grep -A 1 $minion | grep -o "osd\.".* | awk '{print$1}')
+random_osd=$(ceph osd tree | grep -A 1 $minion | grep -Eo "osd\.[[:digit:]]+")
 osd_id=${random_osd#*.}
 
 vg_name=$(salt $minion_fqdn cmd.run "find /var/lib/ceph/osd/ceph-$osd_id -type l -name block \

--- a/qa/tasks/scripts/ses_replace_disk_part2.sh
+++ b/qa/tasks/scripts/ses_replace_disk_part2.sh
@@ -4,7 +4,7 @@ declare -a minion_fqdn="$1"
 
 echo "### Getting random minion and its random OSD ###"
 minion=$(echo $minion_fqdn | cut -d . -f 1)
-random_osd=$(ceph osd tree | grep -A 1 $minion | grep -o "osd\.".* | awk '{print$1}')
+random_osd=$(ceph osd tree | grep -A 1 $minion | grep -Eo "osd\.[[:digit:]]+")
 osd_id=${random_osd#*.}
 
 ceph health | grep HEALTH_OK
@@ -12,4 +12,3 @@ ceph health | grep HEALTH_OK
 ceph osd tree | grep -w $osd_id
 
 ceph osd pool rm replacedisk replacedisk --yes-i-really-really-mean-it
-

--- a/qa/tasks/scripts/ses_stop_osd_daemon.sh
+++ b/qa/tasks/scripts/ses_stop_osd_daemon.sh
@@ -7,7 +7,7 @@ stopped_osd=()
 for i in ${!storage_minions[@]}
 do
     minion=${storage_minions[i]%%.*}
-    random_osd=$(ceph osd tree | grep -A 1 $minion | grep -o osd.* | awk '{print $1}')
+    random_osd=$(ceph osd tree | grep -A 1 $minion | grep -Eo "osd\.[[:digit:]]+")
     salt ${storage_minions[i]} service.stop ceph-osd@${random_osd#*.}
     sleep 5
     echo "Waiting till health is OK."
@@ -26,4 +26,3 @@ do
 done
 
 ceph osd pool rm stoposddeamon stoposddeamon --yes-i-really-really-mean-it
-


### PR DESCRIPTION
Salt's json output was getting polluted with messages like:
	```return event: {'target-ses-023.ecp.suse.de': {'ret': '  WARNING: Failed to connect to lvmetad. Falling back to device scanning.\nvdb', 'retcode': 0, 'jid': '20200704075708748556'}}```
while the expectance was to have 'vdb' only

ses_rgw_zone: add more OSDs to fix TOO_MANY_PGS health warning which was
causing failure
Use "better" regex for fetching OSD ids

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
