### PR TITLE
qa: ses_rack_dc_region_unavailability: Use wildcard suffix for minion

### DIFF
--- a/qa/tasks/scripts/ses_rack_dc_region_unavailability.sh
+++ b/qa/tasks/scripts/ses_rack_dc_region_unavailability.sh
@@ -137,7 +137,7 @@ done
 # bring down rack
 for node2fail in ${rack4_hosts[@]}
 do
-    iptables_drop ${node2fail}.teuthology
+    iptables_drop "${node2fail}.*"
 done
 
 wait_until_down "rack"
@@ -145,7 +145,7 @@ wait_until_down "rack"
 # bring rack up
 for node2fail in ${rack4_hosts[@]}
 do
-    iptables_accept ${node2fail}.teuthology
+    iptables_accept "${node2fail}.*"
 done
 
 cluster_health
@@ -166,7 +166,7 @@ dc2_nodes=(${rack3_hosts[@]} ${rack4_hosts[@]})
 # bringing down DC
 for node2fail in ${dc1_nodes[@]}
 do
-    iptables_drop ${node2fail}.teuthology
+    iptables_drop "${node2fail}.*"
 done
 
 wait_until_down "datacenter"
@@ -174,7 +174,7 @@ wait_until_down "datacenter"
 # bring DC up
 for node2fail in ${dc1_nodes[@]}
 do
-    iptables_accept ${node2fail}.teuthology
+    iptables_accept "${node2fail}.*"
 done
 
 cluster_health
@@ -200,7 +200,7 @@ region2_nodes=(${rack3_hosts[@]} ${rack4_hosts[@]})
 # bringing down region
 for node2fail in ${region1_nodes[@]}
 do
-    iptables_drop ${node2fail}.teuthology
+    iptables_drop "${node2fail}.*"
 done
 
 wait_until_down "region"
@@ -208,7 +208,7 @@ wait_until_down "region"
 # bring region up
 for node2fail in ${region1_nodes[@]}
 do
-    iptables_accept ${node2fail}.teuthology
+    iptables_accept "${node2fail}.*"
 done
 
 cluster_health


### PR DESCRIPTION
Commands tries to run:
`salt target-ses-057.teuthology` while minion is now named
`target-ses-057.ecp.suse.de`

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
