### PR TITLE
[downstream] cephadm: use registry.suse.com by default

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -175,7 +175,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         },
         {
             'name': 'container_image_base',
-            'default': 'docker.io/ceph/ceph',
+            'default': 'registry.suse.com/ses/7/ceph/ceph',
             'desc': 'Container image name, without the tag',
             'runtime': True,
         },


### PR DESCRIPTION
Signed-off-by: Nathan Cutler <ncutler@suse.com>
