### PR TITLE
[DOWNSTREAM] rpm: drop /etc/sudoers.d/cephadm

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1310,7 +1310,6 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 
 # sudoers.d
 install -m 0600 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
-install -m 0600 -D sudoers.d/cephadm %{buildroot}%{_sysconfdir}/sudoers.d/cephadm
 
 %if 0%{?rhel} >= 8
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/*
@@ -1473,7 +1472,6 @@ exit 0
 %files -n cephadm
 %{_sbindir}/cephadm
 %{_mandir}/man8/cephadm.8*
-%{_sysconfdir}/sudoers.d/cephadm
 %attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm
 %attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm/.ssh
 %attr(0600,cephadm,cephadm) %{_sharedstatedir}/cephadm/.ssh/authorized_keys

--- a/sudoers.d/cephadm
+++ b/sudoers.d/cephadm
@@ -1,7 +1,0 @@
-# allow cephadm user to sudo cephadm
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * ls
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * unit *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * shell *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * deploy *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * ceph-volume *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * rm-daemon *


### PR DESCRIPTION
This file is not needed and its presence prevents ceph-salt from
setting up "cephadm" as the cluster admin user.

Signed-off-by: Nathan Cutler <ncutler@suse.com>