### PR TITLE
SES6: qa: Disable 3m sleep after stage.3 and add boilerplate to functional-{1,3}node tests

### DIFF
--- a/qa/suites/deepsea/functional-1node/boilerplate
+++ b/qa/suites/deepsea/functional-1node/boilerplate
@@ -1,0 +1,1 @@
+.qa/deepsea/boilerplate

--- a/qa/suites/deepsea/functional-3nodes/boilerplate
+++ b/qa/suites/deepsea/functional-3nodes/boilerplate
@@ -1,0 +1,1 @@
+.qa/deepsea/boilerplate

--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -1226,12 +1226,6 @@ class Orch(DeepSea):
             'ceph_cluster_status.sh',
             )
         self.__ceph_health_test()
-        self.log.info("Entering temporary post-Stage-3 sleep (3 minutes). "
-                      "Purpose is to avoid transient failures that started "
-                      "appearing with ceph 14.2.9. Once the DeepSea suite "
-                      "is shown to pass reliably on 14.2.9+ without this sleep, "
-                      "it can be removed.")
-        time.sleep(180)
 
     def _run_stage_4(self):
         """


### PR DESCRIPTION
- Current ceph version for SES6 is 14.2.11+ so this timeout should not be needed.
- Hardware runs for `tier2/functional-{1,3}node/s` lacks the `disable-subvolume-check.yaml` which is provided by the `boilerplate` folder.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""


[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---


<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
