### PR TITLE
ceph-volume: batch: call the right prepare method

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -435,7 +435,7 @@ class Batch(object):
             args = osd.get_args(defaults)
             if self.args.prepare:
                 p = Prepare([])
-                p.prepare(argparse.Namespace(**args))
+                p.safe_prepare(argparse.Namespace(**args))
             else:
                 c = Create([])
                 c.create(argparse.Namespace(**args))


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

(cherry-picked from 7c0583332d839f7589461d4aba3a45cb43b1f0d4)

This is a hotfix commit for rook deployments.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
