### PR TITLE
ceph.spec: drop use of DISABLE_RESTART_ON_UPDATE (SUSE specific)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1016,8 +1016,7 @@ fi
 /sbin/ldconfig
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-disk@\*.service ceph.target
+%service_del_postun_without_restart ceph-disk@\*.service ceph.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-disk@\*.service ceph.target
@@ -1164,8 +1163,7 @@ fi
 %postun mds
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mds@\*.service ceph-mds.target
+%service_del_postun_without_restart ceph-mds@\*.service ceph-mds.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mds@\*.service ceph-mds.target
@@ -1213,8 +1211,7 @@ fi
 %postun mgr
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mgr@\*.service ceph-mgr.target
+%service_del_postun_without_restart ceph-mgr@\*.service ceph-mgr.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mgr@\*.service ceph-mgr.target
@@ -1265,8 +1262,7 @@ fi
 %postun mon
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mon@\*.service ceph-mon.target
+%service_del_postun_without_restart ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mon@\*.service ceph-mon.target
@@ -1324,8 +1320,7 @@ fi
 %postun -n rbd-mirror
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
+%service_del_postun_without_restart ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
@@ -1380,8 +1375,7 @@ fi
 %postun radosgw
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-radosgw@\*.service ceph-radosgw.target
+%service_del_postun_without_restart ceph-radosgw@\*.service ceph-radosgw.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-radosgw@\*.service ceph-radosgw.target
@@ -1440,8 +1434,7 @@ fi
 %postun osd
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-osd@\*.service ceph-osd.target
+%service_del_postun_without_restart ceph-osd@\*.service ceph-osd.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-osd@\*.service ceph-osd.target


### PR DESCRIPTION
This variable is deprecated and use of
%service_del_postun_without_restart macro should be preferred these
days.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
