### PR TITLE
ceph-volume: lvmcache: print help correctly

### DIFF
--- a/src/ceph-volume/plugin/lvmcache/ceph_volume_lvmcache/main.py
+++ b/src/ceph-volume/plugin/lvmcache/ceph_volume_lvmcache/main.py
@@ -405,7 +405,7 @@ def rm_lvmcache(origin_lv):
 
 class LVMCache(object):
 
-    help_menu = 'Manage LVM cache'
+    help = help_menu = 'Manage LVM cache'
     _help = """
 Manage lvmcache.
 
@@ -456,7 +456,7 @@ $> ceph-volume lvmcache dump
         self.argv = argv
 
 
-    def help(self):
+    def print_help(self):
         return self._help
 
 
@@ -465,7 +465,7 @@ $> ceph-volume lvmcache dump
         parser = argparse.ArgumentParser(
             prog='lvmcache',
             formatter_class=argparse.RawDescriptionHelpFormatter,
-            description=self.help(),
+            description=self.print_help(),
         )
         parser.add_argument(
             '--cachemetadata',


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes: bsc#1175781

This was meant to be fixed on ses7 first, but the plugin was dropped. Still need the fix in ses6.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
