### PR TITLE
Revert "spec: Podman (temporarily) requires apparmor-abstractions on suse"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -416,9 +416,6 @@ Base is the package that includes all the files shared amongst ceph servers
 %package -n cephadm
 Summary:        Utility to bootstrap Ceph clusters
 Requires:       lvm2
-%if 0%{?suse_version}
-Requires:       apparmor-abstractions
-%endif
 Requires:       python%{python3_pkgversion}
 %if 0%{?weak_deps}
 Recommends:     podman


### PR DESCRIPTION
This reverts commit 070e5c3e35ea476815ff9fa4f71aed147fe1ea79.

Since bsc#1160619 is fixed, this commit is no longer needed

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1177643
Signed-off-by: Nathan Cutler <ncutler@suse.com>
