### PR TITLE
qa/tasks/cep_salt: Fix timeserver path

### DIFF
--- a/qa/tasks/ceph_salt.py
+++ b/qa/tasks/ceph_salt.py
@@ -287,7 +287,7 @@ class CephSalt(Task):
                               .format(ceph_salt_ctx['container_image']))
         self.ctx.ceph[self.cluster].image = ceph_salt_ctx['container_image']
         self.master_remote.sh("sudo ceph-salt "
-                              "config /time_server/server_hostname set {}"
+                              "config /time_server/servers add {}"
                               .format(self.master_remote.hostname))
         self.master_remote.sh("sudo ceph-salt config "
                               "/time_server/external_servers add"


### PR DESCRIPTION
Change timeserver path in ceph-salt as per changes on https://github.com/ceph/ceph-salt/pull/439

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
