### PR TITLE
mgr/dashboard: fix downstream NFS doc links

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
@@ -29,8 +29,8 @@ export class DocService {
     const sections = {
       iscsi: `${domain}ses-admin/#dashboard-iscsi-management`,
       prometheus: `${domain}ses-deployment/#deploy-cephadm-day2-service-monitoring`,
-      'nfs-ganesha': `${domain}ses-admin/#ceph-nfsganesha-config`,
-      'rgw-nfs': `${domain}ses-admin/#ceph-nfsganesha-config-service-rgw`,
+      'nfs-ganesha': `${domain}ses-admin/#cha-ceph-nfsganesha`,
+      'rgw-nfs': `${domain}ses-admin/#ganesha-rgw-supported-operations`,
       rgw: `${domain}ses-admin/#dashboard-ogw-enabling`,
       dashboard: `${domain}ses-admin/#dashboard-initial-configuration`,
       grafana: `${domain}ses-deployment/#deploy-cephadm-day2-service-monitoring`,


### PR DESCRIPTION
The anchors are changed in the downstream docs.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1178073
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
