### PR TITLE
cephadm: set default container_image to registry.suse.com/ses/7/ceph/ceph

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -445,7 +445,7 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by cephadm orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("docker.io/ceph/ceph:v15"),
+    .set_default("registry.suse.com/ses/7/ceph/ceph:latest"),
 
     Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)


### PR DESCRIPTION
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1178531
Signed-off-by: Tim Serong <tserong@suse.com>