### PR TITLE
qa/deepsea/tier2/nfs-ganesha: insert sleep before ganesha.report

### DIFF
--- a/qa/suites/deepsea/tier2/nfs-ganesha/2-services-and-test/cephfs.yaml
+++ b/qa/suites/deepsea/tier2/nfs-ganesha/2-services-and-test/cephfs.yaml
@@ -9,5 +9,6 @@ tasks:
         - exec:
                 client.salt_master:
                         - 'ceph -s'
+                        - 'sleep 300'
         - deepsea.validation:
                 ganesha_smoke_test:

--- a/qa/suites/deepsea/tier2/nfs-ganesha/2-services-and-test/rgw.yaml
+++ b/qa/suites/deepsea/tier2/nfs-ganesha/2-services-and-test/rgw.yaml
@@ -7,5 +7,6 @@ tasks:
         - exec:
                 client.salt_master:
                         - 'ceph -s'
+                        - 'sleep 300'
         - deepsea.validation:
                 ganesha_smoke_test:


### PR DESCRIPTION
After the DeepSea Stages complete, we were running ganesha.report immediately
and seeing the following error:

    Exception: Object conf-target-ses-060 does not exist

indicating that the rados object created during Stage 4 is somehow not created
(or not _fully_ created?) and that more time is needed.

Obviously this is not an ideal fix. Ideally, the rados command for creating the
object would not return before the object is fully created.

References: https://bugzilla.suse.com/show_bug.cgi?id=1179621
Signed-off-by: Nathan Cutler <ncutler@suse.com>
