### PR TITLE
ceph-volume: pass --filter-for-batch from drive-group subcommand

### DIFF
--- a/src/ceph-volume/ceph_volume/drive_group/main.py
+++ b/src/ceph-volume/ceph_volume/drive_group/main.py
@@ -90,7 +90,7 @@ class Deploy(object):
     def get_dg_spec(self, dg):
         dg_spec = DriveGroupSpec._from_json_impl(dg)
         dg_spec.validate()
-        i = Inventory([])
+        i = Inventory(['--filter-for-batch'])
         i.main()
         inventory = i.get_report()
         devices = [Device.from_json(i) for i in inventory]


### PR DESCRIPTION
Otherwise the drive-group spec potentially tries to pull in the root
device (if it fits).

Fixes: https://tracker.ceph.com/issues/48631
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1180107
Cherry-picks: https://github.com/ceph/ceph/pull/38610

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
(cherry picked from commit a6a03d0f5535a053239ae9e49c53ac9208bb0738)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available @susebot commands</summary>

- `@susebot run make check`
- `@susebot run make check sles`
- `@susebot run make check leap`

</details>
