### PR TITLE
iscsi_smoke_test: fix mask for by-path iscsi host device

### DIFF
--- a/qa/tasks/scripts/iscsi_smoke_test.sh
+++ b/qa/tasks/scripts/iscsi_smoke_test.sh
@@ -74,7 +74,7 @@ sleep 5
 
 ls -l /dev/disk/by-path
 ls -l /dev/disk/by-*id
-iscsi_dev=/dev/disk/by-path/*${my_ip}*iscsi*
+iscsi_dev=/dev/disk/by-path/*${my_ip}:*iscsi*
 if ( mkfs -t xfs $iscsi_dev ) ; then
     :
 else


### PR DESCRIPTION
If we have two nodes and they have similar ip addresses,
like 192.168.0.4 and 192.168.0.40 than the mask will match
all of them, that we do not want to.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
