### PR TITLE
deepsea.yaml: do not fail on 14.2.20 and above

### DIFF
--- a/qa/tasks/deepsea.py
+++ b/qa/tasks/deepsea.py
@@ -1225,6 +1225,7 @@ class Orch(DeepSea):
             self.master_remote,
             'ceph_cluster_status.sh',
             )
+        self.master_remote.sh('sudo ceph config set mon auth_allow_insecure_global_id_reclaim false || true')
         self.__ceph_health_test()
 
     def _run_stage_4(self):


### PR DESCRIPTION
As of 14.2.20 we now have to issue the following command after bringing the
cluster up, otherwise the cluster gets stuck in HEALTH_WARN:

    ceph config set mon auth_allow_insecure_global_id_reclaim false

Signed-off-by: Nathan Cutler <ncutler@suse.com>