### PR TITLE
mgr/mgr_module.py: CLICommand: Fix parsing of kwargs arguments

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -314,11 +314,15 @@ class CLICommand(object):
         for a, d in self.args_dict.items():
             if 'req' in d and d['req'] == "false" and a not in cmd_dict:
                 continue
-            if kwargs_switch or (isinstance(cmd_dict[a], str) and '=' in cmd_dict[a]):
-                mgr.log.debug('found kwarg, assuming all following args are kw style')
-                kwargs_switch = True
+
+            if isinstance(cmd_dict[a], str) and '=' in cmd_dict[a]:
+                k, arg = cmd_dict[a].split('=', 1)
+                if k in self.args_dict:
+                    kwargs_switch = True
+
+            if kwargs_switch:
                 try:
-                    k, arg = cmd_dict[a].split('=')
+                    k, arg = cmd_dict[a].split('=', 1)
                 except ValueError as e:
                     mgr.log.error('found positional arg after switching to kwarg parsing')
                     return -errno.EINVAL, '', 'Error EINVAL: postitional arg not allowed after kwarg'

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -8,6 +8,7 @@ import yaml
 from ceph.deployment.service_spec import ServiceSpec
 from ceph.deployment import inventory
 from ceph.utils import datetime_now
+from mgr_module import HandleCommandResult
 
 from test_orchestrator import TestOrchestrator as _TestOrchestrator
 from tests import mock
@@ -15,7 +16,7 @@ from tests import mock
 from orchestrator import raise_if_exception, Completion, ProgressReference
 from orchestrator import InventoryHost, DaemonDescription, ServiceDescription
 from orchestrator import OrchestratorValidationError
-from orchestrator.module import to_format, preview_table_osd
+from orchestrator.module import to_format, OrchestratorCli, preview_table_osd
 
 
 def _test_resource(data, resource_class, extra=None):
@@ -295,6 +296,18 @@ def test_event_multiline():
     e = OrchestratorEvent(datetime_now(), 'service',
                           'subject', 'ERROR', 'multiline\nmessage')
     assert OrchestratorEvent.from_json(e.to_json()) == e
+
+
+def test_handle_command():
+    cmd = {
+        'prefix': 'orch daemon add',
+        'daemon_type': 'mon',
+        'placement': 'smithi044:[v2:172.21.15.44:3301,v1:172.21.15.44:6790]=c',
+    }
+    m = OrchestratorCli('orchestrator', 0, 0)
+    r = m._handle_command(None, cmd)
+    assert r == HandleCommandResult(
+        retval=-2, stdout='', stderr='No orchestrator configured (try `ceph orch set backend`)')
 
 
 def test_preview_table_osd_smoke():


### PR DESCRIPTION
Make parsing of keyword arguments a bit safer by
makeing sure the key is actually a valid parameter name

Fixes: https://tracker.ceph.com/issues/47185
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
(cherry picked from commit 922f962ae123b94ee7f92722190d19280f4ef6e3)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
