### PR TITLE
[SES5] common: fix build failure caused by updated mozilla-nss

### DIFF
--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -56,6 +56,10 @@ namespace ceph {
 // you *must* use CRYPTO_CXXFLAGS in CMakeLists.txt for including this include
 # include <nss.h>
 # include <pk11pub.h>
+// Get rid of CLEANUP macro, which is an internal implemention
+// detail of mozilla-nss, and conflicts with constructs such as
+// TEST(LibRGW, CLEANUP) in our src/test/librgw_file_marker.cc
+#undef CLEANUP
 
 // NSS thinks a lot of fairly fundamental operations might potentially
 // fail, because it has been written to support e.g. smartcards doing all


### PR DESCRIPTION
mozilla-nss version 3.58 added support for Hybrid Public Key Encryption
in the following commit:

  https://hg.mozilla.org/projects/nss/rev/6e3bc17f05086854ffd2b06f7fae9371f7a0c174

This notably adds "#define CLEANUP [...]" to pk11hpke.h.  This
macro appears to be an internal implementation detail of mozilla-nss,
but is unfortunately exposed in /usr/include/nss3/pk11hpke.h, which
is included indirectly by ceph_crypto.h, and results in build failures
when our "TEST(LibRGW, CLEANUP)" macro is expanded in
src/test/librgw_file_marker.cc.  This is not a problem for Octopus,
becuase NSS support was dropped in that release:

  https://github.com/ceph/ceph/commit/a4ddc4bd857

Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commit 096ad6342af73b9b75e603db64ea290e7707055e)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
