### PR TITLE
[SES7] Notify user that there is a SES7.1 upgrade available

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -47,6 +47,7 @@ from .settings import options_command_list, options_schema_list, \
 
 from .plugins import PLUGIN_MANAGER
 from .plugins import feature_toggles, debug, motd  # noqa # pylint: disable=unused-import
+from .plugins import ses7p_motd  # noqa # pylint: disable=unused-import
 
 
 PLUGIN_MANAGER.hook.init()

--- a/src/pybind/mgr/dashboard/plugins/ses7p_motd.py
+++ b/src/pybind/mgr/dashboard/plugins/ses7p_motd.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import hashlib
+import json
+
+from mgr_module import Option
+
+from . import PLUGIN_MANAGER as PM
+from . import interfaces as I  # noqa: E741,N812
+
+
+@PM.add_plugin  # pylint: disable=too-many-ancestors
+class SES7PMotd(I.CanMgr, I.Setupable, I.HasOptions):
+    @PM.add_hook
+    def get_options(self):
+        return [Option(
+            name='ses7p_motd_enabled',
+            default=False,
+            type='bool',
+            desc='Enable the SES 7.1 message of the day')]
+
+    @PM.add_hook
+    def setup(self):
+        # Check whether the MOTD has already been enabled. This is
+        # done to ensure the SES7P announcement is not enabled on
+        # every start of the Ceph Dashboard module and to allow the
+        # administrator to disable it if necessary.
+        enabled = self.mgr.get_module_option('ses7p_motd_enabled')
+        if enabled:
+            return
+        # Note, we can not call the 'ceph dashboard motd set ...' command
+        # here because it is not available at this time. To workaround
+        # this issue we build and write the MOTD configuration ourself.
+        message = 'There is an upgrade to SES 7.1 available, please check the ' \
+                  '<a href="https://documentation.suse.com/ses/7/html/ses-all/upgrade-to-pacific.html">' \
+                  'documentation</a> for more information.'  # noqa # pylint: disable=line-too-long
+        value: str = json.dumps({
+            'message': message,
+            'md5': hashlib.md5(message.encode()).hexdigest(),
+            'severity': 'danger',
+            'expires': 0
+        })
+        self.mgr.set_module_option('motd', value)
+        self.mgr.set_module_option('ses7p_motd_enabled', True)


### PR DESCRIPTION
![Bildschirmfoto vom 2022-03-09 11-08-04](https://user-images.githubusercontent.com/1897962/157420183-48ab8f2d-b078-4399-81dc-8a1c617d1354.png)

Let the Dashboard module configure the MOTD itself instead doing that via cephadm or ceph-salt. The new approach seems to be the easier way.
To do so, the Dashboard plugin 'ses7p_motd' has been introduced. This should prevent or reduce the number of merge conflicts.
The plugin makes sure it will not configure the MOTD on every start of the Ceph Dashboard module. This way it is possible that the administrator can disable the MOTD manually.

Fixes: https://jira.suse.com/browse/SES-2697

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
