### PR TITLE
cephadm: downstream-ify default container image paths

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3,10 +3,10 @@
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'registry.suse.com/ses/7/ceph/ceph:latest'
 DEFAULT_IMAGE_IS_MASTER = False
-DEFAULT_PROMETHEUS_IMAGE = 'quay.io/prometheus/prometheus:v2.18.1'
-DEFAULT_NODE_EXPORTER_IMAGE = 'quay.io/prometheus/node-exporter:v0.18.1'
-DEFAULT_ALERT_MANAGER_IMAGE = 'quay.io/prometheus/alertmanager:v0.20.0'
-DEFAULT_GRAFANA_IMAGE = 'quay.io/ceph/ceph-grafana:6.7.4'
+DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/caasp/v4.5/prometheus-server:2.18.0'
+DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/caasp/v4.5/prometheus-node-exporter:0.18.1'
+DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.16.2'
+DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.3.1'
 # ------------------------------------------------------------------------------
 
 LATEST_STABLE_RELEASE = 'octopus'

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -92,10 +92,10 @@ CEPH_TYPES = set(CEPH_UPGRADE_ORDER)
 
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'registry.suse.com/ses/7/ceph/ceph'
-DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/caasp/v5/prometheus-server:2.18.0'
-DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/caasp/v5/prometheus-node-exporter:0.17.0'
-DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/caasp/v5/prometheus-alertmanager:0.16.2'
-DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.0.3'
+DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/caasp/v4.5/prometheus-server:2.18.0'
+DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/caasp/v4.5/prometheus-node-exporter:0.18.1'
+DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.16.2'
+DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.3.1'
 # ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
This commit replaces the following three earlier downstream commits:

273ab431cf78ccdc80a7b7b7b6dad47ef847f935 cephadm: use full qualified image names for cephadm
8e915845164d88e70e56fc472764148e50d53fa3 Switch to CaaSP v4.5 container images
584bc37f75d9b372dc5d7dc2a64618f0a7415a52 cephadm: Update Grafana container image from 7.0.3 to 7.3.1

The reason for replacing them is: in Octopus 15.2.15, upstream introduced the
following global variables for storing the default container image paths:

DEFAULT_PROMETHEUS_IMAGE
DEFAULT_NODE_EXPORTER_IMAGE
DEFAULT_ALERT_MANAGER_IMAGE
DEFAULT_GRAFANA_IMAGE

Now that the default image paths are stored in these global variables, the three
original downstream commits no longer applied cleanly. Furthermore, it's cleaner
to "downstream-ify" these four default container images via a single commit
instead of three.

Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
