### PR TITLE
Update Prometheus Container image paths

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3,7 +3,7 @@
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'registry.suse.com/ses/7/ceph/ceph:latest'
 DEFAULT_IMAGE_IS_MASTER = False
-DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1'
+DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-server:2.32.1'
 DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2'
 DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0'
 DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.3.1'

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3,9 +3,9 @@
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'registry.suse.com/ses/7/ceph/ceph:latest'
 DEFAULT_IMAGE_IS_MASTER = False
-DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-server:2.32.1'
-DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2'
-DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0'
+DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/ceph/prometheus-server:2.32.1'
+DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/ses/7/ceph/prometheus-node-exporter:1.1.2'
+DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/ses/7/ceph/prometheus-alertmanager:0.21.0'
 DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.3.1'
 # ------------------------------------------------------------------------------
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -92,7 +92,7 @@ CEPH_TYPES = set(CEPH_UPGRADE_ORDER)
 
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'registry.suse.com/ses/7/ceph/ceph'
-DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-server:2.27.1'
+DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-server:2.32.1'
 DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2'
 DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0'
 DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.3.1'

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -92,9 +92,9 @@ CEPH_TYPES = set(CEPH_UPGRADE_ORDER)
 
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'registry.suse.com/ses/7/ceph/ceph'
-DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-server:2.32.1'
-DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-node-exporter:1.1.2'
-DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/ses/7/prometheus/prometheus-alertmanager:0.21.0'
+DEFAULT_PROMETHEUS_IMAGE = 'registry.suse.com/ses/7/ceph/prometheus-server:2.32.1'
+DEFAULT_NODE_EXPORTER_IMAGE = 'registry.suse.com/ses/7/ceph/prometheus-node-exporter:1.1.2'
+DEFAULT_ALERT_MANAGER_IMAGE = 'registry.suse.com/ses/7/ceph/prometheus-alertmanager:0.21.0'
 DEFAULT_GRAFANA_IMAGE = 'registry.suse.com/ses/7/ceph/grafana:7.3.1'
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
*  update prometheus-server image version from `2.27.1` to `2.32.1`
*  monitoring stack container images will have moved to the `ceph` path

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
