### PR TITLE
[SES7P] include/buffer: include <memory>

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -41,6 +41,7 @@
 #include <iosfwd>
 #include <iomanip>
 #include <list>
+#include <memory>
 #include <vector>
 #include <string>
 #if __cplusplus >= 201703L


### PR DESCRIPTION
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1194875