### PR TITLE
ceph.spec.in: remove build directory during %clean (bsc#1196733) 

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1442,6 +1442,9 @@ install -m 644 -D monitoring/prometheus/alerts/ceph_default_alerts.yml %{buildro
 
 %clean
 rm -rf %{buildroot}
+# built binaries are no longer necessary at this point,
+# but are consuming ~17GB of disk in the build environment
+rm -rf build
 
 #################################################################################
 # files and systemd scriptlets


### PR DESCRIPTION
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1196733
Fixes: https://tracker.ceph.com/issues/55079
Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commits aa18cb12003e3526c8e8f23dc2335a483fbfa68e and 94ad178bdcbae56a8eafc65a3a276e25d7a51a5e)
