### PR TITLE
ses7p: mgr/cephadm: allow unsigned plugins

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/grafana/grafana.ini.j2
+++ b/src/pybind/mgr/cephadm/templates/services/grafana/grafana.ini.j2
@@ -22,3 +22,5 @@
   cookie_secure = true
   cookie_samesite = none
   allow_embedding = true
+[plugins]
+  allow_loading_unsigned_plugins = vonage-status-panel,grafana-piechart-panel


### PR DESCRIPTION
From Grafana v8.0 all plugins are required to be signed: https://grafana.com/docs/grafana/latest/installation/upgrading/#plugins

We're using plugins whose highest available version (on Github) is unsigned. As a result the plugin within the Grafana dashboard can't be loaded.
We can workaround it for now by adding the `allow_loading_unsigned_plugins`option to the grafana.ini template.
Once all required plugins are signed we should remove the option again.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
