### PR TITLE
mgr/dashboard: Incorrect MTU mismatch warning

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -233,7 +233,7 @@ groups:
             rate of the past 48 hours.
 
       - alert: MTU Mismatch
-        expr: node_network_mtu_bytes{device!="lo"} != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
+        expr: node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0) != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
         labels:
           severity: warning
           type: ceph_default

--- a/monitoring/prometheus/alerts/test_alerts.yml
+++ b/monitoring/prometheus/alerts/test_alerts.yml
@@ -667,13 +667,27 @@ tests:
     - series: 'node_network_mtu_bytes{device="eth4",instance="node-exporter",
       job="node-exporter"}'
       values: '9000 9000 9000 9000 9000'
+    - series: 'node_network_up{device="eth0",instance="node-exporter",
+      job="node-exporter"}'
+      values: '0 0 0 0 0'
+    - series: 'node_network_up{device="eth1",instance="node-exporter",
+      job="node-exporter"}'
+      values: '0 0 0 0 0'
+    - series: 'node_network_up{device="eth2",instance="node-exporter",
+      job="node-exporter"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth3",instance="node-exporter",
+      job="node-exporter"}'
+      values: '0 0 0 0 0'
+    - series: 'node_network_up{device="eth4",instance="node-exporter",
+      job="node-exporter"}'
+      values: '1 1 1 1 1'  
    promql_expr_test:
-     - expr: node_network_mtu_bytes{device!="lo"} != on() group_left()
+     - expr: node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0) != on() group_left()
              (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
        eval_time: 1m
        exp_samples:
-         - labels: '{__name__="node_network_mtu_bytes", device="eth4",
-           instance="node-exporter", job="node-exporter"}'
+         - labels: '{device="eth4", instance="node-exporter", job="node-exporter"}'
            value: 9000
    alert_rule_test:
      - eval_time: 1m


### PR DESCRIPTION
Backport a fix to SES-6 due to a customer having received a PTF. Upstream tracker refuses to add a backport tracker ticket as Nautilus has been closed, saying `An issue assigned to a closed version cannot be reopened`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
