### PR TITLE
Remove last vestiges of docker.io image paths

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3803,7 +3803,9 @@ def normalize_image_digest(digest: str) -> str:
     """
     Normal case:
     >>> normalize_image_digest('ceph/ceph', 'docker.io')
-    'docker.io/ceph/ceph'
+    Traceback (most recent call last):
+        ...
+    cephadm.Error: Unexpected use of unqualified image name ceph/ceph
 
     No change:
     >>> normalize_image_digest('quay.ceph.io/ceph/ceph', 'docker.io')
@@ -3822,7 +3824,7 @@ def normalize_image_digest(digest: str) -> str:
     ]
     for image in known_shortnames:
         if digest.startswith(image):
-            return f'{DEFAULT_REGISTRY}/{digest}'
+            raise Error('Unexpected use of unqualified image name {}'.format(digest))
     return digest
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -372,7 +372,9 @@ docker.io/ceph/daemon-base:octopus
         assert cd.normalize_image_digest(s) == s
 
         s = 'ceph/ceph:latest'
-        assert cd.normalize_image_digest(s) == f'{cd.DEFAULT_REGISTRY}/{s}'
+        msg = r'Unexpected use of unqualified image name ceph/ceph:latest'
+        with pytest.raises(cd.Error, match=msg):
+            cd.normalize_image_digest(s)
 
     @pytest.mark.parametrize('fsid, ceph_conf, list_daemons, result, err, ',
         [

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -60,4 +60,4 @@ deps =
     flake8-quotes
 commands =
     flake8 --config=tox.ini {posargs:cephadm}
-    bash -c "test $(grep 'docker.io' cephadm | wc -l) == 8"
+    bash -c "test $(grep 'docker.io' cephadm | wc -l) == 7"

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -456,7 +456,7 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by cephadm orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("docker.io/ceph/daemon-base:latest-pacific-devel"),
+    .set_default("registry.suse.com/ses/7.1/ceph/ceph:latest"),
 
     Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -25,7 +25,9 @@ def normalize_image_digest(digest: str, default_registry: str) -> str:
     """
     Normal case:
     >>> normalize_image_digest('ceph/ceph', 'docker.io')
-    'docker.io/ceph/ceph'
+    Traceback (most recent call last):
+        ...
+    orchestrator._interface.OrchestratorError: Unexpected use of unqualified image name ceph/ceph
 
     No change:
     >>> normalize_image_digest('quay.ceph.io/ceph/ceph', 'docker.io')
@@ -44,7 +46,7 @@ def normalize_image_digest(digest: str, default_registry: str) -> str:
     ]
     for image in known_shortnames:
         if digest.startswith(image):
-            return f'{default_registry}/{digest}'
+            raise OrchestratorError('Unexpected use of unqualified image name {}'.format(digest))
     return digest
 
 

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -133,7 +133,7 @@ modules =
 commands =
     flake8 --config=tox.ini {posargs} \
       {posargs:{[testenv:flake8]modules}}
-    bash -c 'test $(git ls-files cephadm | grep ".py$" | grep -v tests | xargs grep "docker.io" | wc -l) == 10'
+    bash -c 'test $(git ls-files cephadm | grep ".py$" | grep -v tests | xargs grep "docker.io" | wc -l) == 9'
 
 [testenv:jinjalint]
 basepython = python3


### PR DESCRIPTION
Two things here, the main issue being setting the default container_image to registry.suse.com/ses/7.1/ceph/ceph. The other thing is the `normalize_image_digest()` function, which AFAICT is extremely unlikely to actually cause trouble, but just in case it does, I've made it raise an error rather than silently doing something stupid ;-)