### PR TITLE
ceph.spec.in: set BuildRequires fmt < 9

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -200,7 +200,7 @@ BuildRequires:	libblkid-devel >= 2.17
 BuildRequires:	cryptsetup-devel
 BuildRequires:	libcurl-devel
 BuildRequires:	libcap-ng-devel
-BuildRequires:	fmt-devel >= 5.2.1
+BuildRequires:	(fmt-devel >= 5.2.1 with fmt-devel < 9)
 BuildRequires:	pkgconfig(libudev)
 BuildRequires:	libnl3-devel
 BuildRequires:	liboath-devel


### PR DESCRIPTION
This is a temporary downstream fix so that ceph will continue to build on openSUSE Factory, which is updating to fmt 9. Ceph currently fails to build when using fmt 9 (see https://tracker.ceph.com/issues/56610), so this temporary fix will unstick us on Factory until we can get a proper fix upstream.  Note that this BuildRequire *will* work on Factory, because Jan Engelhardt is helpfully adding an fmt-8 pacakge there.

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1202292
Signed-off-by: Tim Serong <tserong@suse.com>