### PR TITLE
ceph.spec.in: Add -DFMT_DEPRECATED_OSTREAM to CXXFLAGS

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1236,7 +1236,7 @@ RPM_OPT_FLAGS="$(echo $RPM_OPT_FLAGS | sed -e 's/^-g /-g1 /g' -e 's/ -g / -g1 /g
 
 export CPPFLAGS="$java_inc"
 export CFLAGS="$RPM_OPT_FLAGS"
-export CXXFLAGS="$RPM_OPT_FLAGS"
+export CXXFLAGS="$RPM_OPT_FLAGS -DFMT_DEPRECATED_OSTREAM"
 export LDFLAGS="$RPM_LD_FLAGS"
 test "$RPM_LD_FLAGS" && echo "RPM_LD_FLAGS == $RPM_LD_FLAGS" || echo "RPM_LD_FLAGS is empty"
 


### PR DESCRIPTION
This is a temporary downstream fix so that Ceph will continue to build on openSUSE Factory, which is updating to fmt version 9.  Ceph currently fails to build when using fmt 9 (see https://tracker.ceph.com/issues/56610), so this fix will unstick us on Factory until we can get a proper fix upstream. Note that per fmt changelog, the FMT_DEPRECATED_OSTREAM define will be removed in the next major release, but we'll be good with this immediately for the time being.  See:
https://github.com/fmtlib/fmt/blob/master/ChangeLog.rst#900---2022-07-04

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1202292
Signed-off-by: Tim Serong <tserong@suse.com>