### PR TITLE
Fix FTBFS on gcc 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.orig
 *.patch
 !debian/patches/*.patch
+!cmake/modules/*.patch
 *.rej
 *.rpm
 *.pyc

--- a/cmake/modules/BuildRocksDB.cmake
+++ b/cmake/modules/BuildRocksDB.cmake
@@ -1,3 +1,6 @@
+# CMAKE_CURRENT_FUNCTION_LIST_DIR is introduced by cmake 3.17, but ubuntu comes with 3.16
+set(_build_rocksdb_list_dir "${CMAKE_CURRENT_LIST_DIR}")
+
 function(build_rocksdb)
   set(rocksdb_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
   list(APPEND rocksdb_CMAKE_ARGS -DWITH_GFLAGS=OFF)
@@ -79,10 +82,12 @@ function(build_rocksdb)
     set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target rocksdb)
   endif()
 
+  find_program(PATCH_EXECUTABLE patch)
   ExternalProject_Add(rocksdb_ext
     SOURCE_DIR "${rocksdb_SOURCE_DIR}"
     CMAKE_ARGS ${rocksdb_CMAKE_ARGS}
     BINARY_DIR "${rocksdb_BINARY_DIR}"
+    PATCH_COMMAND ${PATCH_EXECUTABLE} -p1 -i ${_build_rocksdb_list_dir}/rocksdb-gcc-13.patch
     BUILD_COMMAND "${make_cmd}"
     BUILD_BYPRODUCTS "${rocksdb_LIBRARY}"
     INSTALL_COMMAND "true"

--- a/cmake/modules/rocksdb-gcc-13.patch
+++ b/cmake/modules/rocksdb-gcc-13.patch
@@ -1,0 +1,86 @@
+From fe4d03d15e662a195bf28cb1327fbaeb563efb13 Mon Sep 17 00:00:00 2001
+From: Heiko Becker <heirecka@exherbo.org>
+Date: Tue, 24 Jan 2023 16:23:03 +0100
+Subject: [PATCH] Fix build with gcc 13 by including <cstdint>
+
+Like other versions before, gcc 13 moved some includes around and as a
+result <cstdint> is no longer transitively included [1]. Explicitly include
+it for uint{32,64}_t.
+
+[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
+---
+ table/block_based/data_block_hash_index.h | 1 +
+ util/string_util.h                        | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/table/block_based/data_block_hash_index.h b/table/block_based/data_block_hash_index.h
+index f356395f329..3215221755d 100644
+--- a/table/block_based/data_block_hash_index.h
++++ b/table/block_based/data_block_hash_index.h
+@@ -5,6 +5,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/util/string_util.h b/util/string_util.h
+index 55d106fff02..11178fd1d7b 100644
+--- a/util/string_util.h
++++ b/util/string_util.h
+@@ -6,6 +6,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <sstream>
+ #include <string>
+ #include <unordered_map>
+From 31012cdfa435d9203da3c3de8127b66bf018692a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 24 Jan 2023 21:40:43 -0800
+Subject: [PATCH] checkpoint.h: Add missing includes <cstdint>
+
+It uses uint64_t and it comes from <cstdint>
+This is needed with GCC 13 and newer [1]
+
+[1] https://www.gnu.org/software/gcc/gcc-13/porting_to.html
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ include/rocksdb/utilities/checkpoint.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/rocksdb/utilities/checkpoint.h b/include/rocksdb/utilities/checkpoint.h
+index 6046513aba4..ecf92061629 100644
+--- a/include/rocksdb/utilities/checkpoint.h
++++ b/include/rocksdb/utilities/checkpoint.h
+@@ -8,6 +8,7 @@
+ #pragma once
+ #ifndef ROCKSDB_LITE
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+--- a/db/compaction/compaction_iteration_stats.h
++++ b/db/compaction/compaction_iteration_stats.h
+@@ -5,6 +5,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include "rocksdb/rocksdb_namespace.h"
+ 
+ struct CompactionIterationStats {
+--- a/third-party/folly/folly/synchronization/detail/ProxyLockable-inl.h
++++ b/third-party/folly/folly/synchronization/detail/ProxyLockable-inl.h
+@@ -13,6 +13,7 @@
+ #include <memory>
+ #include <mutex>
+ #include <stdexcept>
++#include <system_error>
+ #include <utility>
+ 
+ namespace folly {

--- a/src/common/Cycles.h
+++ b/src/common/Cycles.h
@@ -29,8 +29,9 @@
  */
 
 
-#ifndef CEPH_CYCLES_H
-#define CEPH_CYCLES_H
+#pragma once
+
+#include <cstdint>
 
 /**
  * This class provides static methods that read the fine-grain CPU
@@ -112,4 +113,3 @@ private:
   }
 };
 
-#endif  // CEPH_CYCLES_H

--- a/src/common/subsys_types.h
+++ b/src/common/subsys_types.h
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 
 enum ceph_subsys_id_t {
   ceph_subsys_,   // default

--- a/src/librbd/api/PoolMetadata.h
+++ b/src/librbd/api/PoolMetadata.h
@@ -7,6 +7,7 @@
 #include "include/buffer_fwd.h"
 #include "include/rados/librados_fwd.hpp"
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/test/mon/test_log_rss_usage.cc
+++ b/src/test/mon/test_log_rss_usage.cc
@@ -1,4 +1,5 @@
 #include <sys/types.h>
+#include <cstdint>
 #include <dirent.h>
 #include <errno.h>
 #include <vector>


### PR DESCRIPTION
This was reported on the openSUSE side at https://bugzilla.suse.com/show_bug.cgi?id=1201088 and also upstream by one of the Fedora folks at https://tracker.ceph.com/issues/58477.

I've done several builds of this, first to make sure it doesn't break existing (older) GCC in:

- https://build.opensuse.org/package/show/home:tserong:branches:filesystems:ceph/ceph
- https://build.suse.de/package/show/home:tserong:branches:Devel:Storage:7.0:Pacific/ceph

...and of course to make sure it works with GCC 13, but I did that on my local machine with `osc build --alternative-project devel:gcc:next ceph.spec`.

I'm currently working on submitting this upstream too, but the fix to upstream main is slightly different than in pacific and may take a little longer to sort out.