### PR TITLE
ceph-volume: fix regression in activate

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -101,16 +101,16 @@ class List(object):
                                     'failed to determine if parent device {} is BlueStore. err: {}'.format(parent, e)))
                         continue
 
-                bs_info = _get_bluestore_info(dev)
-                if bs_info is None:
-                    # None is also returned in the rare event that there is an issue reading info from
-                    # a BlueStore disk, so be sure to log our assumption that it isn't bluestore
-                    logger.info('device {} does not have BlueStore information'.format(dev))
-                    continue
-                uuid = bs_info['osd_uuid']
-                if uuid not in result:
-                    result[uuid] = {}
-                result[uuid].update(bs_info)
+            bs_info = _get_bluestore_info(dev)
+            if bs_info is None:
+                # None is also returned in the rare event that there is an issue reading info from
+                # a BlueStore disk, so be sure to log our assumption that it isn't bluestore
+                logger.info('device {} does not have BlueStore information'.format(dev))
+                continue
+            uuid = bs_info['osd_uuid']
+            if uuid not in result:
+                result[uuid] = {}
+            result[uuid].update(bs_info)
 
         return result
 


### PR DESCRIPTION
bea9f4b643c introduced a regression that makes the activate process take a very long time to complete.
`_get_bluestore_info()` which calls `ceph-bluestore-tool` binary via subprocess is called in an exponential way while this is not needed.

Fixes: https://tracker.ceph.com/issues/57627

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 8d7423c3e75afbe111c91e699ef3cb1c0beee61b)
