### PR TITLE
cmake: patch boost source to support python 3.11

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -176,6 +176,7 @@ function(do_build_boost version)
   ExternalProject_Add(Boost
     ${source_dir}
     PATCH_COMMAND ${PATCH_EXECUTABLE} -p3 -i ${_build_boost_list_dir}/boost-python-use-public-api-for-filename.patch
+    COMMAND ${PATCH_EXECUTABLE} -p3 -i ${_build_boost_list_dir}/boost-python-fix-python-310-pep-620-incompatibility.patch
     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${configure_command}
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1

--- a/cmake/modules/boost-python-fix-python-310-pep-620-incompatibility.patch
+++ b/cmake/modules/boost-python-fix-python-310-pep-620-incompatibility.patch
@@ -1,0 +1,136 @@
+From 500194edb7833d0627ce7a2595fec49d0aae2484 Mon Sep 17 00:00:00 2001
+From: Stefan Seefeld <stefan@seefeld.name>
+Date: Fri, 13 Nov 2020 21:17:24 -0500
+Subject: [PATCH] Fix Python 3.10 (PEP-620) incompatibility.
+
+---
+ include/boost/python/detail/wrap_python.hpp   |  4 ++++
+ include/boost/python/object/make_instance.hpp |  2 +-
+ src/object/class.cpp                          | 15 +++++----------
+ src/object/enum.cpp                           |  2 +-
+ src/object/function.cpp                       |  2 +-
+ src/object/life_support.cpp                   |  2 +-
+ 6 files changed, 13 insertions(+), 14 deletions(-)
+
+diff --git a/include/boost/python/detail/wrap_python.hpp b/include/boost/python/detail/wrap_python.hpp
+index 9d5f5422a2..037e4bf2ec 100644
+--- a/src/boost/boost/python/detail/wrap_python.hpp
++++ b/src/boost/boost/python/detail/wrap_python.hpp
+@@ -227,7 +227,11 @@ typedef int pid_t;
+ 
+ # define PyVarObject_HEAD_INIT(type, size) \
+         PyObject_HEAD_INIT(type) size,
++#endif
+ 
++#if PY_VERSION_HEX < 0x030900A4
++#  define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
++#  define Py_SET_SIZE(obj, size) ((Py_SIZE(obj) = (size)), (void)0)
+ #endif
+ 
+ 
+diff --git a/include/boost/python/object/make_instance.hpp b/include/boost/python/object/make_instance.hpp
+index 31ec08f7c3..5eb3aa9d9c 100644
+--- a/src/boost/boost/python/object/make_instance.hpp
++++ b/src/boost/boost/python/object/make_instance.hpp
+@@ -47,7 +47,7 @@ struct make_instance_impl
+               
+             // Note the position of the internally-stored Holder,
+             // for the sake of destruction
+-            Py_SIZE(instance) = offsetof(instance_t, storage);
++            Py_SET_SIZE(instance, offsetof(instance_t, storage));
+ 
+             // Release ownership of the python object
+             protect.cancel();
+diff --git a/src/object/class.cpp b/src/object/class.cpp
+index 9bb9683a31..c6bab76009 100644
+--- a/src/boost/libs/python/src/object/class.cpp
++++ b/src/boost/libs/python/src/object/class.cpp
+@@ -208,7 +208,7 @@ namespace objects
+   {
+       if (static_data_object.tp_dict == 0)
+       {
+-          Py_TYPE(&static_data_object) = &PyType_Type;
++          Py_SET_TYPE(&static_data_object, &PyType_Type);
+           static_data_object.tp_base = &PyProperty_Type;
+           if (PyType_Ready(&static_data_object))
+               return 0;
+@@ -316,7 +316,7 @@ namespace objects
+   {
+       if (class_metatype_object.tp_dict == 0)
+       {
+-          Py_TYPE(&class_metatype_object) = &PyType_Type;
++          Py_SET_TYPE(&class_metatype_object, &PyType_Type);
+           class_metatype_object.tp_base = &PyType_Type;
+           if (PyType_Ready(&class_metatype_object))
+               return type_handle();
+@@ -374,12 +374,7 @@ namespace objects
+               // like, so we'll store the total size of the object
+               // there. A negative number indicates that the extra
+               // instance memory is not yet allocated to any holders.
+-#if PY_VERSION_HEX >= 0x02060000
+-              Py_SIZE(result) =
+-#else
+-              result->ob_size =
+-#endif
+-                  -(static_cast<int>(offsetof(instance<>,storage) + instance_size));
++              Py_SET_SIZE(result,-static_cast<int>(offsetof(instance<>,storage) + instance_size));
+           }
+           return (PyObject*)result;
+       }
+@@ -470,7 +465,7 @@ namespace objects
+   {
+       if (class_type_object.tp_dict == 0)
+       {
+-          Py_TYPE(&class_type_object) = incref(class_metatype().get());
++          Py_SET_TYPE(&class_type_object, incref(class_metatype().get()));
+           class_type_object.tp_base = &PyBaseObject_Type;
+           if (PyType_Ready(&class_type_object))
+               return type_handle();
+@@ -739,7 +734,7 @@ void* instance_holder::allocate(PyObject* self_, std::size_t holder_offset, std:
+         assert(holder_offset >= offsetof(objects::instance<>,storage));
+ 
+         // Record the fact that the storage is occupied, noting where it starts
+-        Py_SIZE(self) = holder_offset;
++        Py_SET_SIZE(self, holder_offset);
+         return (char*)self + holder_offset;
+     }
+     else
+diff --git a/src/object/enum.cpp b/src/object/enum.cpp
+index 10122ad1da..293e705899 100644
+--- a/src/boost/libs/python/src/object/enum.cpp
++++ b/src/boost/libs/python/src/object/enum.cpp
+@@ -153,7 +153,7 @@ namespace
+   {
+       if (enum_type_object.tp_dict == 0)
+       {
+-          Py_TYPE(&enum_type_object) = incref(&PyType_Type);
++          Py_SET_TYPE(&enum_type_object, incref(&PyType_Type));
+ #if PY_VERSION_HEX >= 0x03000000
+           enum_type_object.tp_base = &PyLong_Type;
+ #else
+diff --git a/src/object/function.cpp b/src/object/function.cpp
+index 9d4745d102..787679e138 100644
+--- a/src/boost/libs/python/src/object/function.cpp
++++ b/src/boost/libs/python/src/object/function.cpp
+@@ -107,7 +107,7 @@ function::function(
+     PyObject* p = this;
+     if (Py_TYPE(&function_type) == 0)
+     {
+-        Py_TYPE(&function_type) = &PyType_Type;
++        Py_SET_TYPE(&function_type, &PyType_Type);
+         ::PyType_Ready(&function_type);
+     }
+     
+diff --git a/src/object/life_support.cpp b/src/object/life_support.cpp
+index b7e9aa861e..281c3bffc5 100644
+--- a/src/boost/libs/python/src/object/life_support.cpp
++++ b/src/boost/libs/python/src/object/life_support.cpp
+@@ -93,7 +93,7 @@ PyObject* make_nurse_and_patient(PyObject* nurse, PyObject* patient)
+     
+     if (Py_TYPE(&life_support_type) == 0)
+     {
+-        Py_TYPE(&life_support_type) = &PyType_Type;
++        Py_SET_TYPE(&life_support_type, &PyType_Type);
+         PyType_Ready(&life_support_type);
+     }
+     


### PR DESCRIPTION
The included patch comes from https://github.com/boostorg/python/commit/500194edb7833d0627ce7a2595fec49d0aae2484

Note that in BuildBoost.cmake, additional patches just use COMMAND, not PATCH_COMMAND (see "Miscellaneous Options" at https://cmake.org/cmake/help/latest/module/ExternalProject.html)

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1210944
