### PR TITLE
ceph.spec.in: enable build on riscv64 for openSUSE Factory

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -155,7 +155,7 @@ URL:		http://ceph.com/
 Source0:	%{?_remote_tarball_prefix}@TARBALL_BASENAME@.tar.bz2
 %if 0%{?suse_version}
 # _insert_obs_source_lines_here
-ExclusiveArch:  x86_64 aarch64 ppc64le s390x
+ExclusiveArch:  x86_64 aarch64 ppc64le s390x riscv64
 %endif
 #################################################################################
 # dependencies that apply across all distro families


### PR DESCRIPTION
Signed-off-by: Andreas Schwab <schwab@suse.de>
(cherry picked from commit c7f5037293737322a20617bd7e43ab28da258d22)