### PR TITLE
ceph.spec.in: Require Cython >= 0.29 but < 3

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -307,7 +307,7 @@ BuildRequires:  openldap2-devel
 #BuildRequires:  krb5-devel
 BuildRequires:  cunit-devel
 BuildRequires:	python%{python3_pkgversion}-setuptools
-BuildRequires:	python%{python3_pkgversion}-Cython
+BuildRequires:	(python%{python3_pkgversion}-Cython >= 0.29 with python%{python3_pkgversion}-Cython < 3)
 BuildRequires:	python%{python3_pkgversion}-PrettyTable
 BuildRequires:	python%{python3_pkgversion}-Sphinx
 BuildRequires:  rdma-core-devel


### PR DESCRIPTION
This is based on a change made to fix the build on openSUSE Factory which now includes Cython 0.29.x and Cython 3:

  https://build.opensuse.org/request/show/1104240

Ceph currently only builds with Cython 0.29, hence the need to exclude version 3 which would otherwise be used by default.

Unfortunately the fix for Factory doesn't work when building against SLE 15 SP3, due to older python macros, hence this version.
