### PR TITLE
ceph.spec.in: Require fmt-devel < 10 (bsc#1213217)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -200,7 +200,7 @@ BuildRequires:	libblkid-devel >= 2.17
 BuildRequires:	cryptsetup-devel
 BuildRequires:	libcurl-devel
 BuildRequires:	libcap-ng-devel
-BuildRequires:	fmt-devel >= 5.2.1
+BuildRequires:	((fmt-devel >= 5.2.1 with fmt-devel < 10) or fmt-9-devel)
 BuildRequires:	pkgconfig(libudev)
 BuildRequires:	libnl3-devel
 BuildRequires:	liboath-devel


### PR DESCRIPTION
openSUSE Factory is upgrading to fmt version 10, but Ceph fails to build with that.  A separate package (fmt-9) has been created in Factory so we can use that instead.  The trick here is to set the BuildRequires to it will use the regular fmt-devel package if a version < 10 is available (e.g. on SLE 15 SP3 for SES 7.1), but to use fmt-9-devel otherwise.
