### PR TITLE
make-dist: strip "-%{release}" from ceph package Requires

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -185,6 +185,13 @@ for spec in ceph.spec.in; do
         sed "s/@RPM_RELEASE@/$rpm_release/g" |
         sed "s/@TARBALL_BASENAME@/ceph-$version/g" > `echo $spec | sed 's/.in$//'`
 done
+
+case $ID in
+    opensuse*|suse|sles)
+        sed -i 's/^\(Requires.*\)-%{release}/\1/g' `echo $spec | sed 's/.in$//'`
+        ;;
+esac
+
 ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
 # NOTE: If you change this version number make sure the package is available


### PR DESCRIPTION
Requring %{version}-%{release} doesn't make sense on SUSE distros, because %{version} already contains everything we need (e.g.: 16.2.13.66+g54799ee0666), while %{release} is an internal detail of the SUSE build service.  Indeed, if these packages have a hard requirement on the latter, it can cause conflicts when installing ceph packages with multiple update channels active (e.g. SES 7.1 Updates and SLE 15 SP3 Basesystem Updates) when the release number differs between channels, but the packages are otherwise identical.