### PR TITLE
ceph.spec.in: Advertise users/groups that are generated by the pre scripts

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -464,6 +464,8 @@ Requires:       python%{python3_pkgversion}
 %if 0%{?weak_deps}
 Recommends:     podman >= 2.0.2
 %endif
+Provides:       user(cephadm)
+Provides:       group(cephadm)
 %description -n cephadm
 Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 
 with systemd and podman.
@@ -501,6 +503,8 @@ Obsoletes:      libradosstriper1 <= %{_epoch_prefix}%{version}-%{release}
 PreReq:         permissions
 Requires(pre):	shadow
 %endif
+Provides:       user(ceph)
+Provides:       group(ceph)
 %description -n ceph-common
 Common utilities to mount and interact with a ceph storage cluster.
 Comprised of files that are common to Ceph clients and servers.


### PR DESCRIPTION
This is needed for RPM 4.19.  For the original submission, see: https://build.opensuse.org/request/show/1141481.