### PR TITLE
Fix FTBFS on GCC 14 (boo#1222493)

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -219,6 +219,29 @@ for tarball in $outfile.version   \
     rm $tarball.tar
 done
 mv $outfile.all.tar $outfile.tar
+patch -p0 <<EOF
+--- src/rapidjson/include/rapidjson/document.h.orig	2024-04-09 16:01:06.252689115 +1000
++++ src/rapidjson/include/rapidjson/document.h	2024-04-09 16:01:29.129152799 +1000
+@@ -316,8 +316,6 @@
+ 
+     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
+ 
+-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+-
+     //! implicit conversion to plain CharType pointer
+     operator const Ch *() const { return s; }
+ 
+@@ -328,6 +326,8 @@
+     //! Disallow construction from non-const array
+     template<SizeType N>
+     GenericStringRef(CharType (&str)[N]) /* = delete */;
++    //! Copy assignment operator not permitted - immutable type
++    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
+ };
+ 
+ //! Mark a character pointer as constant string
+EOF
+tar --update -f $outfile.tar $outfile/src/rapidjson/include/rapidjson/document.h
 rm $outfile
 
 echo "compressing..."

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -146,17 +146,27 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 #else
 #define dout_impl(cct, sub, v)						\
   do {									\
-  const bool should_gather = [&](const auto cctX) {			\
-    if constexpr (ceph::dout::is_dynamic<decltype(sub)>::value ||	\
-		  ceph::dout::is_dynamic<decltype(v)>::value) {		\
+  const bool should_gather = [&](const auto cctX, auto sub_, auto v_) {	\
+    /* The check is performed on `sub_` and `v_` to leverage the C++'s 	\
+     * guarantee on _discarding_ one of blocks of `if constexpr`, which	\
+     * includes also the checks for ill-formed code (`should_gather<>`	\
+     * must not be feed with non-const expresions), BUT ONLY within	\
+     * a template (thus the generic lambda) and under the restriction	\
+     * it's dependant on a parameter of this template).			\
+     * GCC prior to v14 was not enforcing these restrictions. */	\
+    if constexpr (ceph::dout::is_dynamic<decltype(sub_)>::value ||	\
+		  ceph::dout::is_dynamic<decltype(v_)>::value) {	\
       return cctX->_conf->subsys.should_gather(sub, v);			\
     } else {								\
+      constexpr auto sub_helper = static_cast<decltype(sub_)>(sub);	\
+      constexpr auto v_helper = static_cast<decltype(v_)>(v);		\
       /* The parentheses are **essential** because commas in angle	\
        * brackets are NOT ignored on macro expansion! A language's	\
        * limitation, sorry. */						\
-      return (cctX->_conf->subsys.template should_gather<sub, v>());	\
+      return (cctX->_conf->subsys.template should_gather<sub_helper,	\
+							 v_helper>());	\
     }									\
-  }(cct);								\
+  }(cct, sub, v);							\
 									\
   if (should_gather) {							\
     ceph::logging::MutableEntry _dout_e(v, sub);                        \

--- a/src/include/rados/rgw_file.h
+++ b/src/include/rados/rgw_file.h
@@ -221,7 +221,7 @@ int rgw_unlink(struct rgw_fs *rgw_fs,
 /*
     read  directory content
 */
-typedef bool (*rgw_readdir_cb)(const char *name, void *arg, uint64_t offset,
+typedef int (*rgw_readdir_cb)(const char *name, void *arg, uint64_t offset,
 			       struct stat *st, uint32_t mask,
 			       uint32_t flags);
 

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -2,6 +2,7 @@
 
 from libc.stdint cimport *
 from ctime cimport time_t, timespec
+cimport libcpp
 
 cdef extern from "rados/librados.h":
     enum:
@@ -515,7 +516,7 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_snap_unprotect(rbd_image_t image, const char *snap_name)
     int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
                               int *is_protected)
-    int rbd_snap_exists(rbd_image_t image, const char *snapname, bint *exists)
+    int rbd_snap_exists(rbd_image_t image, const char *snapname, libcpp.bool *exists)
     int rbd_snap_get_limit(rbd_image_t image, uint64_t *limit)
     int rbd_snap_set_limit(rbd_image_t image, uint64_t limit)
     int rbd_snap_get_timestamp(rbd_image_t image, uint64_t snap_id, timespec *timestamp)
@@ -701,7 +702,7 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_namespace_list(rados_ioctx_t io, char *namespace_names,
                            size_t *size)
     int rbd_namespace_exists(rados_ioctx_t io, const char *namespace_name,
-                             bint *exists)
+                             libcpp.bool *exists)
 
     int rbd_pool_init(rados_ioctx_t, bint force)
 

--- a/src/pybind/rbd/mock_rbd.pxi
+++ b/src/pybind/rbd/mock_rbd.pxi
@@ -3,6 +3,11 @@
 from libc.stdint cimport *
 from ctime cimport time_t, timespec
 
+# Make the bool type available as libcpp.bool, for both C and C++.
+cimport libcpp
+cdef extern from "<stdbool.h>":
+    pass
+
 cdef nogil:
     enum:
         _LIBRADOS_SNAP_HEAD "LIBRADOS_SNAP_HEAD"
@@ -627,7 +632,7 @@ cdef nogil:
     int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
                               int *is_protected):
         pass
-    int rbd_snap_exists(rbd_image_t image, const char *snapname, bint *exists):
+    int rbd_snap_exists(rbd_image_t image, const char *snapname, libcpp.bool *exists):
         pass
     int rbd_snap_get_limit(rbd_image_t image, uint64_t *limit):
         pass
@@ -886,7 +891,7 @@ cdef nogil:
                            size_t *size):
         pass
     int rbd_namespace_exists(rados_ioctx_t io, const char *namespace_name,
-                             bint *exists):
+                             libcpp.bool *exists):
         pass
     int rbd_pool_init(rados_ioctx_t io, bint force):
         pass

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -23,6 +23,7 @@ from libc cimport errno
 from libc.stdint cimport *
 from libc.stdlib cimport realloc, free
 from libc.string cimport strdup
+cimport libcpp
 
 try:
     from collections.abc import Iterable
@@ -1934,12 +1935,12 @@ class RBD(object):
         cdef:
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             const char *_name = name
-            bint _exists = False
+            libcpp.bool _exists = False
         with nogil:
             ret = rbd_namespace_exists(_ioctx, _name, &_exists)
         if ret != 0:
             raise make_ex(ret, 'error verifying namespace')
-        return bool(_exists != 0)
+        return _exists
 
     def namespace_list(self, ioctx):
         """
@@ -3678,12 +3679,12 @@ cdef class Image(object):
         name = cstr(name, 'name')
         cdef:
             char *_name = name
-            bint _exists = False
+            libcpp.bool _exists = False
         with nogil:
             ret = rbd_snap_exists(self.image, _name, &_exists)
         if ret != 0:
             raise make_ex(ret, 'error getting snapshot exists for %s' % self.name)
-        return bool(_exists != 0)
+        return _exists
 
     @requires_not_closed
     def get_snap_limit(self):

--- a/src/pybind/rgw/mock_rgw.pxi
+++ b/src/pybind/rgw/mock_rgw.pxi
@@ -1,5 +1,10 @@
 # cython: embedsignature=True
 
+# Make the bool type available as libcpp.bool, for both C and C++.
+cimport libcpp
+cdef extern from "<stdbool.h>":
+    pass
+
 cdef nogil:
     ctypedef void* librgw_t
 
@@ -111,8 +116,8 @@ cdef nogil:
 
     int rgw_readdir(rgw_fs *fs,
                     rgw_file_handle *parent_fh, uint64_t *offset,
-                    bint (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
-                    void *cb_arg, bint *eof, uint32_t flags) except? -9000:
+                    libcpp.bool (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
+                    void *cb_arg, libcpp.bool *eof, uint32_t flags) except? -9000:
         pass
 
     int rgw_getattr(rgw_fs *fs,

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -7,6 +7,7 @@ from cpython cimport PyObject, ref, exc, array
 from libc.stdint cimport *
 from libc.stdlib cimport malloc, realloc, free
 from cstat cimport stat
+cimport libcpp
 
 IF BUILD_DOC:
     include "mock_rgw.pxi"
@@ -373,7 +374,7 @@ cdef class LibRGWFS(object):
         cdef:
             rgw_file_handle *_dir_handler = <rgw_file_handle*>dir_handler.handler
             uint64_t _offset = offset
-            bint _eof
+            libcpp.bool _eof
             uint32_t _flags = flags
         with nogil:
             ret = rgw_readdir(self.fs, _dir_handler, &_offset, &readdir_cb,

--- a/src/test/librgw_file.cc
+++ b/src/test/librgw_file.cc
@@ -71,7 +71,7 @@ TEST(LibRGW, GETATTR_ROOT) {
 }
 
 extern "C" {
-  static bool r1_cb(const char* name, void *arg, uint64_t offset,
+  static int r1_cb(const char* name, void *arg, uint64_t offset,
 		    struct stat* st, uint32_t st_mask,
 		    uint32_t flags) {
     // don't need arg--it would point to fids1
@@ -135,7 +135,7 @@ TEST(LibRGW, GETATTR_BUCKETS) {
 }
 
 extern "C" {
-  static bool r2_cb(const char* name, void *arg, uint64_t offset,
+  static int r2_cb(const char* name, void *arg, uint64_t offset,
 		    struct stat* st, uint32_t st_mask,
 		    uint32_t flags) {
     std::vector<fid_type>& obj_vector = *(static_cast<std::vector<fid_type>*>(arg));

--- a/src/test/librgw_file_gp.cc
+++ b/src/test/librgw_file_gp.cc
@@ -211,7 +211,7 @@ TEST(LibRGW, LOOKUP_BUCKET) {
 }
 
 extern "C" {
-  static bool r2_cb(const char* name, void *arg, uint64_t offset,
+  static int r2_cb(const char* name, void *arg, uint64_t offset,
 		    struct stat *st, uint32_t st_mask,
 		    uint32_t flags) {
     // don't need arg--it would point to fids

--- a/src/test/librgw_file_marker.cc
+++ b/src/test/librgw_file_marker.cc
@@ -290,7 +290,7 @@ TEST(LibRGW, MARKER1_SETUP_OBJECTS)
 }
 
 extern "C" {
-  static bool r2_cb(const char* name, void *arg, uint64_t offset,
+  static int r2_cb(const char* name, void *arg, uint64_t offset,
 		    struct stat* st, uint32_t st_mask,
 		    uint32_t flags) {
     dirent_vec& dvec =

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -869,7 +869,7 @@ TEST(LibRGW, RELEASE_DIRS1) {
 }
 
 extern "C" {
-  static bool r1_cb(const char* name, void *arg, uint64_t offset,
+  static int r1_cb(const char* name, void *arg, uint64_t offset,
 		    struct stat* st, uint32_t st_mask,
 		    uint32_t flags) {
     struct rgw_file_handle* parent_fh
@@ -1027,7 +1027,7 @@ TEST(LibRGW, MARKER1_SETUP_OBJECTS)
 }
 
 extern "C" {
-  static bool r2_cb(const char* name, void *arg, uint64_t offset,
+  static int r2_cb(const char* name, void *arg, uint64_t offset,
 		    struct stat* st, uint32_t st_mask,
 		    uint32_t flags) {
     dirent_vec& dvec =

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -2586,7 +2586,7 @@ TRACEPOINT_EVENT(librados, rados_watch3_enter,
     TP_FIELDS(
         ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
         ctf_string(oid, oid)
-        ctf_integer_hex(uint64_t, phandle, phandle)
+        ctf_integer_hex(uint64_t*, phandle, phandle)
         ctf_integer_hex(rados_watchcb2_t, callback, callback)
         ctf_integer(uint32_t, timeout, timeout)
         ctf_integer_hex(void*, arg, arg)
@@ -2616,7 +2616,7 @@ TRACEPOINT_EVENT(librados, rados_aio_watch2_enter,
         ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
         ctf_string(oid, oid)
         ctf_integer_hex(rados_completion_t, completion, completion)
-        ctf_integer_hex(uint64_t, phandle, phandle)
+        ctf_integer_hex(uint64_t*, phandle, phandle)
         ctf_integer_hex(rados_watchcb2_t, callback, callback)
         ctf_integer(uint32_t, timeout, timeout)
         ctf_integer_hex(void*, arg, arg)

--- a/src/tracing/tracing-common.h
+++ b/src/tracing/tracing-common.h
@@ -21,7 +21,7 @@
 // type should be an integer type
 // val should have type type*
 #define ceph_ctf_integerp(type, field, val) \
-    ctf_integer(type, field, (val) == NULL ? 0 : (val)) \
+    ctf_integer(type, field, (val) == NULL ? 0 : *(val)) \
     ctf_integer(uint8_t, field##_isnull, (val) == NULL)
 
 // val should have type char*


### PR DESCRIPTION
This is a backport of:

- https://github.com/ceph/ceph/pull/54974
- https://github.com/ceph/ceph/pull/55306
- https://github.com/ceph/ceph/pull/48828

Plus, unexpectedly (see my comments in the commit message):

- https://github.com/Tencent/rapidjson/commit/862c39be371278a45a88d4d1d75164be57bb7e2d

At the time of writing, test builds are succeeding for openSUSE Leap 15.3, 15.4, and Tumbleweed at https://build.opensuse.org/package/show/home:tserong:branches:filesystems:ceph/ceph.

I've successfully done a local build against gcc 14 by running `osc build --noservice --ccache --vm-type=chroot --disable-debuginfo --clean --alternative-project home:rguenther:nextgcc ceph.spec`.