### PR TITLE
Support Python 3.13

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -177,6 +177,7 @@ function(do_build_boost version)
     ${source_dir}
     PATCH_COMMAND ${PATCH_EXECUTABLE} -p3 -i ${_build_boost_list_dir}/boost-python-use-public-api-for-filename.patch
     COMMAND ${PATCH_EXECUTABLE} -p3 -i ${_build_boost_list_dir}/boost-python-fix-python-310-pep-620-incompatibility.patch
+    COMMAND ${PATCH_EXECUTABLE} -p3 -i ${_build_boost_list_dir}/boost-python-stop-using-deprecated-api-calls.patch
     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${configure_command}
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1

--- a/cmake/modules/boost-python-stop-using-deprecated-api-calls.patch
+++ b/cmake/modules/boost-python-stop-using-deprecated-api-calls.patch
@@ -1,0 +1,68 @@
+From 944fa075b321cf53a972dfd0e9bab11cc194ee15 Mon Sep 17 00:00:00 2001
+From: Pat Riehecky <riehecky@fnal.gov>
+Date: Wed, 14 Oct 2020 13:54:24 -0500
+Subject: [PATCH] Stop using deprecated API calls (python-3.9) #319
+
+---
+ include/boost/python/call.hpp        | 4 ++--
+ include/boost/python/call_method.hpp | 2 +-
+ include/boost/python/override.hpp    | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/boost/python/call.hpp b/include/boost/python/call.hpp
+index 5d2d7d2341..c057ee9a12 100644
+--- a/src/boost/boost/python/call.hpp
++++ b/src/boost/boost/python/call.hpp
+@@ -60,7 +60,7 @@ call(PyObject* callable
+     )
+ {
+     PyObject* const result = 
+-        PyEval_CallFunction(
++        PyObject_CallFunction(
+             callable
+             , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")
+             BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FAST_ARG_TO_PYTHON_GET, nil)
+@@ -69,7 +69,7 @@ call(PyObject* callable
+     // This conversion *must not* be done in the same expression as
+     // the call, because, in the special case where the result is a
+     // reference a Python object which was created by converting a C++
+-    // argument for passing to PyEval_CallFunction, its reference
++    // argument for passing to PyObject_CallFunction, its reference
+     // count will be 2 until the end of the full expression containing
+     // the conversion, and that interferes with dangling
+     // pointer/reference detection.
+diff --git a/include/boost/python/call_method.hpp b/include/boost/python/call_method.hpp
+index 410f66820e..424077eab4 100644
+--- a/src/boost/boost/python/call_method.hpp
++++ b/src/boost/boost/python/call_method.hpp
+@@ -69,7 +69,7 @@ call_method(PyObject* self, char const* name
+     // This conversion *must not* be done in the same expression as
+     // the call, because, in the special case where the result is a
+     // reference a Python object which was created by converting a C++
+-    // argument for passing to PyEval_CallFunction, its reference
++    // argument for passing to PyObject_CallFunction, its reference
+     // count will be 2 until the end of the full expression containing
+     // the conversion, and that interferes with dangling
+     // pointer/reference detection.
+diff --git a/include/boost/python/override.hpp b/include/boost/python/override.hpp
+index 39714257f9..b631226fd6 100644
+--- a/src/boost/boost/python/override.hpp
++++ b/src/boost/boost/python/override.hpp
+@@ -97,7 +97,7 @@ class override : public object
+     operator()() const
+     {
+         detail::method_result x(
+-            PyEval_CallFunction(
++            PyObject_CallFunction(
+                 this->ptr()
+               , const_cast<char*>("()")
+             ));
+@@ -132,7 +132,7 @@ detail::method_result
+ operator()( BOOST_PP_ENUM_BINARY_PARAMS_Z(1, N, A, const& a) ) const
+ {
+     detail::method_result x(
+-        PyEval_CallFunction(
++        PyObject_CallFunction(
+             this->ptr()
+           , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")
+             BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_fast_arg_to_python_get, nil)

--- a/make-dist
+++ b/make-dist
@@ -196,12 +196,13 @@ ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
 # NOTE: If you change this version number make sure the package is available
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
-boost_version=1.73.0
-download_boost $boost_version 4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402 \
+boost_version=1.75.0
+download_boost $boost_version 953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb \
                https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa
-download_liburing 0.7 05d0cf8493d573c76b11abfcf34aabc7153affebe17ff95f9ae88b0de062a59d \
+download_liburing 0.7 8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543 \
+                  https://github.com/axboe/liburing/archive \
                   https://git.kernel.dk/cgit/liburing/snapshot
 pmdk_version=1.10
 download_pmdk $pmdk_version 08dafcf94db5ac13fac9139c92225d9aa5f3724ea74beee4e6ca19a01a2eb20c \

--- a/make-dist
+++ b/make-dist
@@ -196,8 +196,8 @@ ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
 # NOTE: If you change this version number make sure the package is available
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
-boost_version=1.75.0
-download_boost $boost_version 953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb \
+boost_version=1.73.0
+download_boost $boost_version 4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402 \
                https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -189,72 +189,6 @@ void PyModuleConfig::set_config(
   }
 }
 
-std::string PyModule::get_site_packages()
-{
-  std::stringstream site_packages;
-
-  // CPython doesn't auto-add site-packages dirs to sys.path for us,
-  // but it does provide a module that we can ask for them.
-  auto site_module = PyImport_ImportModule("site");
-  ceph_assert(site_module);
-
-  auto site_packages_fn = PyObject_GetAttrString(site_module, "getsitepackages");
-  if (site_packages_fn != nullptr) {
-    auto site_packages_list = PyObject_CallObject(site_packages_fn, nullptr);
-    ceph_assert(site_packages_list);
-
-    auto n = PyList_Size(site_packages_list);
-    for (Py_ssize_t i = 0; i < n; ++i) {
-      if (i != 0) {
-        site_packages << ":";
-      }
-      site_packages << PyUnicode_AsUTF8(PyList_GetItem(site_packages_list, i));
-    }
-
-    Py_DECREF(site_packages_list);
-    Py_DECREF(site_packages_fn);
-  } else {
-    // Fall back to generating our own site-packages paths by imitating
-    // what the standard site.py does.  This is annoying but it lets us
-    // run inside virtualenvs :-/
-
-    auto site_packages_fn = PyObject_GetAttrString(site_module, "addsitepackages");
-    ceph_assert(site_packages_fn);
-
-    auto known_paths = PySet_New(nullptr);
-    auto pArgs = PyTuple_Pack(1, known_paths);
-    PyObject_CallObject(site_packages_fn, pArgs);
-    Py_DECREF(pArgs);
-    Py_DECREF(known_paths);
-    Py_DECREF(site_packages_fn);
-
-    auto sys_module = PyImport_ImportModule("sys");
-    ceph_assert(sys_module);
-    auto sys_path = PyObject_GetAttrString(sys_module, "path");
-    ceph_assert(sys_path);
-
-    dout(1) << "sys.path:" << dendl;
-    auto n = PyList_Size(sys_path);
-    bool first = true;
-    for (Py_ssize_t i = 0; i < n; ++i) {
-      dout(1) << "  " << PyUnicode_AsUTF8(PyList_GetItem(sys_path, i)) << dendl;
-      if (first) {
-        first = false;
-      } else {
-        site_packages << ":";
-      }
-      site_packages << PyUnicode_AsUTF8(PyList_GetItem(sys_path, i));
-    }
-
-    Py_DECREF(sys_path);
-    Py_DECREF(sys_module);
-  }
-
-  Py_DECREF(site_module);
-
-  return site_packages.str();
-}
-
 PyObject* PyModule::init_ceph_logger()
 {
   auto py_logger = PyModule_Create(&ceph_logger_module);
@@ -319,13 +253,6 @@ int PyModule::load(PyThreadState *pMainThreadState)
       // fake one.  This step also picks up site-packages into sys.path.
       const wchar_t *argv[] = {L"ceph-mgr"};
       PySys_SetArgv(1, (wchar_t**)argv);
-      // Configure sys.path to include mgr_module_path
-      string paths = (g_conf().get_val<std::string>("mgr_module_path") + ':' +
-                      get_site_packages() + ':');
-      wstring sys_path(wstring(begin(paths), end(paths)) + Py_GetPath());
-      PySys_SetPath(const_cast<wchar_t*>(sys_path.c_str()));
-      dout(10) << "Computed sys.path '"
-	       << string(begin(sys_path), end(sys_path)) << "'" << dendl;
     }
   }
   // Environment is all good, import the external module

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -49,7 +49,6 @@ class PyModule
   mutable ceph::mutex lock = ceph::make_mutex("PyModule::lock");
 private:
   const std::string module_name;
-  std::string get_site_packages();
   int load_subclass_of(const char* class_name, PyObject** py_class);
 
   // Did the MgrMap identify this module as one that should run?

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -23,6 +23,8 @@ namespace fs = std::experimental::filesystem;
 #error std::filesystem not available!
 #endif
 
+#include <boost/scope_exit.hpp>
+
 #include "include/stringify.h"
 #include "common/errno.h"
 #include "common/split.h"
@@ -52,21 +54,37 @@ void PyModuleRegistry::init()
 
   // Set up global python interpreter
 #define WCHAR(s) L ## #s
-  Py_SetProgramName(const_cast<wchar_t*>(WCHAR(MGR_PYTHON_EXECUTABLE)));
-#undef WCHAR
+  PyConfig py_config;
+  // do not enable isolated mode, otherwise we would not be able to have access
+  // to the site packages. since we cannot import any module before initializing
+  // the interpreter, we would not be able to use "site" module for retrieving
+  // the path to site packager. we import "site" module for retrieving
+  // sitepackages in Python < 3.8 though, this does not apply to the
+  // initialization with PyConfig.
+  PyConfig_InitPythonConfig(&py_config);
+  BOOST_SCOPE_EXIT_ALL(&py_config) {
+    PyConfig_Clear(&py_config);
+  };
+#if PY_VERSION_HEX >= 0x030b0000
+  py_config.safe_path = 0;
+#endif
+  py_config.parse_argv = 0;
+  py_config.configure_c_stdio = 0;
+  py_config.install_signal_handlers = 0;
+  py_config.pathconfig_warnings = 0;
+
+  PyStatus status;
+  status = PyConfig_SetString(&py_config, &py_config.program_name, WCHAR(MGR_PYTHON_EXECUTABLE));
+  ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetString: %s:%s", status.func, status.err_msg);
   // Add more modules
   if (g_conf().get_val<bool>("daemonize")) {
     PyImport_AppendInittab("ceph_logger", PyModule::init_ceph_logger);
   }
   PyImport_AppendInittab("ceph_module", PyModule::init_ceph_module);
-  Py_InitializeEx(0);
-#if PY_VERSION_HEX < 0x03090000
-  // Let CPython know that we will be calling it back from other
-  // threads in future.
-  if (! PyEval_ThreadsInitialized()) {
-    PyEval_InitThreads();
-  }
-#endif
+  status = Py_InitializeFromConfig(&py_config);
+  ceph_assertf(!PyStatus_Exception(status), "Py_InitializeFromConfig: %s:%s", status.func, status.err_msg);
+#undef WCHAR
+
   // Drop the GIL and remember the main thread state (current
   // thread state becomes NULL)
   pMainThreadState = PyEval_SaveThread();

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -81,6 +81,15 @@ void PyModuleRegistry::init()
     PyImport_AppendInittab("ceph_logger", PyModule::init_ceph_logger);
   }
   PyImport_AppendInittab("ceph_module", PyModule::init_ceph_module);
+  // Configure sys.path to include mgr_module_path
+  auto pythonpath_env = g_conf().get_val<std::string>("mgr_module_path");
+  if (const char* pythonpath = getenv("PYTHONPATH")) {
+    pythonpath_env += ":";
+    pythonpath_env += pythonpath;
+  }
+  status = PyConfig_SetBytesString(&py_config, &py_config.pythonpath_env, pythonpath_env.data());
+  ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetBytesString: %s:%s", status.func, status.err_msg);
+  dout(10) << "set PYTHONPATH to " << std::quoted(pythonpath_env) << dendl;
   status = Py_InitializeFromConfig(&py_config);
   ceph_assertf(!PyStatus_Exception(status), "Py_InitializeFromConfig: %s:%s", status.func, status.err_msg);
 #undef WCHAR
@@ -286,6 +295,72 @@ void PyModuleRegistry::shutdown()
 
   PyEval_RestoreThread(pMainThreadState);
   Py_Finalize();
+}
+
+std::string PyModuleRegistry::get_site_packages()
+{
+  std::stringstream site_packages;
+
+  // CPython doesn't auto-add site-packages dirs to sys.path for us,
+  // but it does provide a module that we can ask for them.
+  auto site_module = PyImport_ImportModule("site");
+  ceph_assert(site_module);
+
+  auto site_packages_fn = PyObject_GetAttrString(site_module, "getsitepackages");
+  if (site_packages_fn != nullptr) {
+    auto site_packages_list = PyObject_CallObject(site_packages_fn, nullptr);
+    ceph_assert(site_packages_list);
+
+    auto n = PyList_Size(site_packages_list);
+    for (Py_ssize_t i = 0; i < n; ++i) {
+      if (i != 0) {
+        site_packages << ":";
+      }
+      site_packages << PyUnicode_AsUTF8(PyList_GetItem(site_packages_list, i));
+    }
+
+    Py_DECREF(site_packages_list);
+    Py_DECREF(site_packages_fn);
+  } else {
+    // Fall back to generating our own site-packages paths by imitating
+    // what the standard site.py does.  This is annoying but it lets us
+    // run inside virtualenvs :-/
+
+    auto site_packages_fn = PyObject_GetAttrString(site_module, "addsitepackages");
+    ceph_assert(site_packages_fn);
+
+    auto known_paths = PySet_New(nullptr);
+    auto pArgs = PyTuple_Pack(1, known_paths);
+    PyObject_CallObject(site_packages_fn, pArgs);
+    Py_DECREF(pArgs);
+    Py_DECREF(known_paths);
+    Py_DECREF(site_packages_fn);
+
+    auto sys_module = PyImport_ImportModule("sys");
+    ceph_assert(sys_module);
+    auto sys_path = PyObject_GetAttrString(sys_module, "path");
+    ceph_assert(sys_path);
+
+    dout(1) << "sys.path:" << dendl;
+    auto n = PyList_Size(sys_path);
+    bool first = true;
+    for (Py_ssize_t i = 0; i < n; ++i) {
+      dout(1) << "  " << PyUnicode_AsUTF8(PyList_GetItem(sys_path, i)) << dendl;
+      if (first) {
+        first = false;
+      } else {
+        site_packages << ":";
+      }
+      site_packages << PyUnicode_AsUTF8(PyList_GetItem(sys_path, i));
+    }
+
+    Py_DECREF(sys_path);
+    Py_DECREF(sys_module);
+  }
+
+  Py_DECREF(site_module);
+
+  return site_packages.str();
 }
 
 std::set<std::string> PyModuleRegistry::probe_modules(const std::string &path) const

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -54,6 +54,7 @@ void PyModuleRegistry::init()
 
   // Set up global python interpreter
 #define WCHAR(s) L ## #s
+#if PY_VERSION_HEX >= 0x030800f0
   PyConfig py_config;
   // do not enable isolated mode, otherwise we would not be able to have access
   // to the site packages. since we cannot import any module before initializing
@@ -76,22 +77,35 @@ void PyModuleRegistry::init()
   PyStatus status;
   status = PyConfig_SetString(&py_config, &py_config.program_name, WCHAR(MGR_PYTHON_EXECUTABLE));
   ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetString: %s:%s", status.func, status.err_msg);
+#else
+  Py_SetProgramName(const_cast<wchar_t*>(WCHAR(MGR_PYTHON_EXECUTABLE)));
+#endif
   // Add more modules
   if (g_conf().get_val<bool>("daemonize")) {
     PyImport_AppendInittab("ceph_logger", PyModule::init_ceph_logger);
   }
   PyImport_AppendInittab("ceph_module", PyModule::init_ceph_module);
+#if PY_VERSION_HEX < 0x03090000
+  Py_InitializeEx(0);
+  // Let CPython know that we will be calling it back from other
+  // threads in future.
+  if (! PyEval_ThreadsInitialized()) {
+    PyEval_InitThreads();
+  }
+#endif
   // Configure sys.path to include mgr_module_path
   auto pythonpath_env = g_conf().get_val<std::string>("mgr_module_path");
   if (const char* pythonpath = getenv("PYTHONPATH")) {
     pythonpath_env += ":";
     pythonpath_env += pythonpath;
   }
+#if PY_VERSION_HEX >= 0x030800f0
   status = PyConfig_SetBytesString(&py_config, &py_config.pythonpath_env, pythonpath_env.data());
   ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetBytesString: %s:%s", status.func, status.err_msg);
   dout(10) << "set PYTHONPATH to " << std::quoted(pythonpath_env) << dendl;
   status = Py_InitializeFromConfig(&py_config);
   ceph_assertf(!PyStatus_Exception(status), "Py_InitializeFromConfig: %s:%s", status.func, status.err_msg);
+#endif
 #undef WCHAR
 
   // Drop the GIL and remember the main thread state (current

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -55,6 +55,7 @@ private:
   // before ClusterState exists.
   MgrMap mgr_map;
 
+  static std::string get_site_packages();
   /**
    * Discover python modules from local disk
    */


### PR DESCRIPTION
Build on top of @danigm 's work to support Python 3.13

Which includes these upstream commits:
https://github.com/ceph/ceph/commit/4cf9b36c66fd
https://github.com/ceph/ceph/commit/51a5774aa605

As well as a boost fix and a new patch on top that adds back Python <3.8 compatibility that upstream removed.

Replaces PR #517 
